### PR TITLE
Validation target redesign

### DIFF
--- a/Light.PortableResults.slnx
+++ b/Light.PortableResults.slnx
@@ -32,6 +32,7 @@
     <File Path="ai-plans\0024-validation-outcome-removal.md" />
     <File Path="ai-plans\0024-validation-support.md" />
     <File Path="ai-plans\0028-child-validation-refactoring.md" />
+    <File Path="ai-plans\0030-validation-target-redesign.md" />
     <File Path="ai-plans\AGENTS.md" />
   </Folder>
   <Folder Name="/benchmarks/">

--- a/README.md
+++ b/README.md
@@ -164,6 +164,36 @@ public sealed class ImportValidator : AsyncValidator<ImportRequest, ImportComman
 }
 ```
 
+For advanced manual target control, use
+`ValidationTarget`
+instead of overloading the string-based `target:` parameter on
+`Check(...)`.
+The common overload still interprets that string like a caller expression, even when you pass it explicitly.
+Use
+`ValidationTarget.Relative(...)`
+for paths below the current validation scope and
+`ValidationTarget.Absolute(...)`
+for already-rooted paths:
+
+```csharp
+using Light.PortableResults.Validation;
+
+var context = validationContextFactory.CreateValidationContext();
+var customerContext = context.ForMember("customer", isNormalized: true);
+
+var relativeCheck = customerContext.Check(
+	request.FirstName,
+	ValidationTarget.Relative("firstName", isNormalized: true),
+	displayName: "First name"
+);
+
+var absoluteCheck = customerContext.Check(
+	request.OwnerName,
+	ValidationTarget.Absolute("account.ownerName", isNormalized: true),
+	displayName: "Owner name"
+);
+```
+
 ## 🚀 HTTP Quick Start
 
 ### Minimal APIs

--- a/ai-plans/0030-validation-target-redesign.md
+++ b/ai-plans/0030-validation-target-redesign.md
@@ -6,16 +6,16 @@ The current validation target model overloads plain strings with too many meanin
 
 ## Acceptance Criteria
 
-- [ ] A dedicated validation-target type is introduced that explicitly distinguishes caller-expression targets, relative targets, and absolute targets instead of encoding these semantics implicitly in plain strings.
-- [ ] The redesign keeps lazy target resolution so that normalized absolute targets are not allocated unless a validation flow actually needs them.
-- [ ] `Check<T>` no longer decides target ownership by comparing target strings with `ValidationContext.TargetPrefix`; target ownership comes from the explicit `ValidationTarget` semantics and the current prefix-detection logic is removed or reduced to trivial assertions.
-- [ ] `ValidationContext` exposes explicit APIs for creating checks from caller-expression, relative, and absolute targets, and for creating child scopes from resolved absolute targets without ambiguous prefixing rules.
-- [ ] Caller-expression normalization is separated from validation-path normalization so that direct relative paths are not treated like caller expressions.
-- [ ] The public check-creation API remains ergonomic for the common case while also exposing explicit advanced entry points for relative and absolute targets.
-- [ ] Child validation, collection validation, error creation, and message-context creation all use the new target model consistently across synchronous and asynchronous flows.
-- [ ] The redesign preserves deterministic target composition and does not regress the current flat-path behavior for representative root, member, and indexed targets.
-- [ ] Automated tests cover the new target semantics, including caller-expression, relative, and absolute targets, plus representative child-validation and collection-validation scenarios.
-- [ ] XML documentation and README examples are updated to describe the explicit target semantics and the recommended APIs for advanced manual target control.
+- [x] A dedicated validation-target type is introduced that explicitly distinguishes caller-expression targets, relative targets, and absolute targets instead of encoding these semantics implicitly in plain strings.
+- [x] The redesign keeps lazy target resolution so that normalized absolute targets are not allocated unless a validation flow actually needs them.
+- [x] `Check<T>` no longer decides target ownership by comparing target strings with `ValidationContext.TargetPrefix`; target ownership comes from the explicit `ValidationTarget` semantics and the current prefix-detection logic is removed or reduced to trivial assertions.
+- [x] `ValidationContext` exposes explicit APIs for creating checks from caller-expression, relative, and absolute targets, and for creating child scopes from resolved absolute targets without ambiguous prefixing rules.
+- [x] Caller-expression normalization is separated from validation-path normalization so that direct relative paths are not treated like caller expressions.
+- [x] The public check-creation API remains ergonomic for the common case while also exposing explicit advanced entry points for relative and absolute targets.
+- [x] Child validation, collection validation, error creation, and message-context creation all use the new target model consistently across synchronous and asynchronous flows.
+- [x] The redesign preserves deterministic target composition and does not regress the current flat-path behavior for representative root, member, and indexed targets.
+- [x] Automated tests cover the new target semantics, including caller-expression, relative, and absolute targets, plus representative child-validation and collection-validation scenarios.
+- [x] XML documentation and README examples are updated to describe the explicit target semantics and the recommended APIs for advanced manual target control.
 
 ## Technical Details
 

--- a/ai-plans/0030-validation-target-redesign.md
+++ b/ai-plans/0030-validation-target-redesign.md
@@ -1,0 +1,130 @@
+# Validation Target Redesign
+
+## Rationale
+
+The current validation target model overloads plain strings with too many meanings. A check target can start as a raw caller expression, become a normalized relative path, or effectively behave like an absolute path inside a nested validation scope. Because this meaning is inferred from string comparisons against `ValidationContext.TargetPrefix`, child-context creation and target normalization need defensive prefix-detection logic that is harder to understand than the underlying rules. This plan redesigns target handling around explicit target semantics so that target ownership is encoded in data instead of inferred from path text. The goal is to make validation targets easier to reason about while preserving the library's flat-path semantics and avoiding unnecessary allocations when no errors are produced.
+
+## Acceptance Criteria
+
+- [ ] A dedicated validation-target type is introduced that explicitly distinguishes caller-expression targets, relative targets, and absolute targets instead of encoding these semantics implicitly in plain strings.
+- [ ] The redesign keeps lazy target resolution so that normalized absolute targets are not allocated unless a validation flow actually needs them.
+- [ ] `Check<T>` no longer decides target ownership by comparing target strings with `ValidationContext.TargetPrefix`; target ownership comes from the explicit `ValidationTarget` semantics and the current prefix-detection logic is removed or reduced to trivial assertions.
+- [ ] `ValidationContext` exposes explicit APIs for creating checks from caller-expression, relative, and absolute targets, and for creating child scopes from resolved absolute targets without ambiguous prefixing rules.
+- [ ] Caller-expression normalization is separated from validation-path normalization so that direct relative paths are not treated like caller expressions.
+- [ ] The public check-creation API remains ergonomic for the common case while also exposing explicit advanced entry points for relative and absolute targets.
+- [ ] Child validation, collection validation, error creation, and message-context creation all use the new target model consistently across synchronous and asynchronous flows.
+- [ ] The redesign preserves deterministic target composition and does not regress the current flat-path behavior for representative root, member, and indexed targets.
+- [ ] Automated tests cover the new target semantics, including caller-expression, relative, and absolute targets, plus representative child-validation and collection-validation scenarios.
+- [ ] XML documentation and README examples are updated to describe the explicit target semantics and the recommended APIs for advanced manual target control.
+
+## Technical Details
+
+Introduce a dedicated target descriptor instead of passing raw strings through the validation pipeline without context.
+The target descriptor should encode two concerns explicitly:
+
+- how the input text must be interpreted
+- whether the input text has already been normalized
+
+Do not use a flags enum for the interpretation itself. Caller-expression, relative, and absolute targets are mutually exclusive semantics, so a closed enum or equivalent representation should enforce that only one of them can be active at a time. Normalization state can be tracked separately. The target descriptor should remain a lightweight value type so that it fits the library's low-allocation design while still behaving like a value object in tests and other comparison scenarios. The plan should use the following structure unless implementation details uncover a strong reason to deviate:
+
+```csharp
+public readonly record struct ValidationTarget
+{
+    public ValidationTarget(
+        string input,
+        ValidationTargetSemantics semantics,
+        bool isNormalized = false
+    )
+    {
+        Input = input ?? throw new ArgumentNullException(nameof(input));
+        if (!IsDefined(semantics))
+        {
+            throw new ArgumentOutOfRangeException(nameof(semantics));
+        }
+
+        Semantics = semantics;
+        IsNormalized = isNormalized;
+    }
+
+    public string Input { get; }
+    public ValidationTargetSemantics Semantics { get; }
+    public bool IsNormalized { get; }
+
+    private static bool IsDefined(ValidationTargetSemantics semantics) =>
+        semantics == ValidationTargetSemantics.CallerExpression ||
+        semantics == ValidationTargetSemantics.Relative ||
+        semantics == ValidationTargetSemantics.Absolute;
+}
+
+public enum ValidationTargetSemantics
+{
+    CallerExpression,
+    Relative,
+    Absolute
+}
+```
+
+Because `Light.PortableResults.Validation` targets .NET Standard 2.0, the undefined-enum-value check should not depend on newer generic `Enum.IsDefined` APIs. Use a dedicated helper or an equivalent explicit comparison that validates the supported `ValidationTargetSemantics` values without relying on unavailable framework overloads.
+
+The target descriptor represents caller intent only. It should not also store the resolved absolute target path. The resolved absolute target remains runtime state on `Check<T>` so that it can stay lazy.
+
+`Check<T>` should move away from the current `Target` plus `IsTargetNormalized` model. Instead, it should store the incoming target descriptor together with an optional resolved absolute target. The resolved absolute target should be filled lazily when the check needs an actual path, for example when creating an error, creating a message context, or creating a child scope. This keeps the common success path allocation-light while still making absolute-target ownership explicit once it matters.
+
+`ValidationContext` should gain explicit entry points for each target semantic instead of forcing all callers through a single caller-expression-oriented path. The common `Check(value, ...)` overload should stay optimized for `CallerArgumentExpression`, and its `target` parameter should continue to mean "caller-expression-style target" even when the caller sets that parameter explicitly. Advanced callers should opt into relative or absolute semantics through the `ValidationTarget` overload rather than relying on string-shape inference. Prefer keeping the current ergonomic overload and adding a target-descriptor overload instead of adding more optional semantic arguments to the existing signature. The intended API shape is:
+
+```csharp
+public Check<T> Check<T>(
+    T value,
+    IStringValueNormalizer? stringValueNormalizer = null,
+    [CallerArgumentExpression("value")] string? target = null,
+    string? displayName = null
+);
+
+public Check<T> Check<T>(
+    T value,
+    ValidationTarget target,
+    IStringValueNormalizer? stringValueNormalizer = null,
+    string? displayName = null
+);
+```
+
+The `ValidationTarget` overload should be treated as the canonical advanced API. This design should cover at least these conceptual operations:
+
+- create a check from a caller expression via the existing ergonomic overload
+- create a check from a relative target via `new ValidationTarget(..., ValidationTargetSemantics.Relative, ...)`
+- create a check from an absolute target via `new ValidationTarget(..., ValidationTargetSemantics.Absolute, ...)`
+- create a child scope from a resolved absolute target
+
+The `ValidationTarget.Input` contract should be explicit:
+
+- `CallerExpression`: `Input` is a caller-expression-style string that must be interpreted by the caller-expression normalization rules unless `IsNormalized` is already `true`
+- `Relative`: `Input` is a path relative to the current validation scope and must never be treated as a caller expression
+- `Absolute`: `Input` is a path that is already rooted for the full validation run and must never be prefixed with the current validation scope
+
+When `IsNormalized` is `true`, the input should already be normalized according to the rules for the specified semantics and must not be normalized again.
+
+The normalizer responsibilities should be split accordingly. A caller-expression target normalizer can continue to trim parameter names and normalize member/index syntax. Direct relative and absolute validation paths should not be routed through the same logic when that logic would reinterpret the first path segment as an object-root identifier. If this requires separate normalizer abstractions or a single abstraction with explicit target semantics, prefer the option that keeps the rules easiest to understand at call sites and in the implementation.
+
+Once the target descriptor is in place, child-scope creation should become straightforward. `Check<T>` should resolve an absolute target once and then hand that absolute target to `ValidationContext` through an explicit absolute-scope API. This should remove the need for prefix/equality/separator heuristics whose only job is to guess whether a target string already includes the current scope prefix.
+
+The redesign should be applied consistently across the validation surface:
+
+- `Check<T>.NormalizeTargetIfNecessary`
+- child-context helpers on `Check<T>`
+- error creation on `Check<T>` and `ValidationContext`
+- message-context creation
+- child validation and collection validation in `CheckExtensions`
+- async child and collection validation paths
+
+Because the library is still pre-stable, breaking changes are acceptable. However, the common validation experience should remain concise. Most callers should still be able to write validators without thinking about target semantics explicitly, while advanced users should have direct, efficient APIs for manual relative and absolute targets when they need them.
+
+The automated tests should verify both semantics and ergonomics. Cover at least the following:
+
+- caller-expression targets resolving to expected flat paths
+- explicitly passing the `target` parameter to the ergonomic `Check(value, ...)` overload still using caller-expression semantics
+- manually specified relative targets being prefixed exactly once
+- manually specified absolute targets not being prefixed again
+- child validation starting from each target semantic
+- collection validation under member and index paths starting from each target semantic
+- sync and async error creation using explicit target semantics
+- message-context creation for caller-expression, relative, and absolute targets

--- a/benchmarks/Benchmarks/ValidationContextBenchmarks.cs
+++ b/benchmarks/Benchmarks/ValidationContextBenchmarks.cs
@@ -37,7 +37,11 @@ public class ValidationErrorAccumulationBenchmarks
         var context = ValidationBenchmarkHelpers.ValidationContextFactory.CreateValidationContext();
         for (var i = 0; i < errorCount; i++)
         {
-            context.AddError($"message {i}", $"Code{i}", $"items[{i}]");
+            context.AddError(
+                $"message {i}",
+                $"Code{i}",
+                ValidationTarget.Relative($"items[{i}]", isNormalized: true)
+            );
         }
 
         return context.ToErrors();
@@ -78,7 +82,11 @@ public class ValidationErrorMaterializationBenchmarks
         var context = ValidationBenchmarkHelpers.ValidationContextFactory.CreateValidationContext();
         for (var i = 0; i < errorCount; i++)
         {
-            context.AddError($"message {i}", $"Code{i}", $"items[{i}]");
+            context.AddError(
+                $"message {i}",
+                $"Code{i}",
+                ValidationTarget.Relative($"items[{i}]", isNormalized: true)
+            );
         }
 
         return context;

--- a/src/Light.PortableResults.Validation/AsyncValidator.cs
+++ b/src/Light.PortableResults.Validation/AsyncValidator.cs
@@ -28,13 +28,35 @@ public abstract class AsyncValidator<T> : BaseValidator<T>
     /// </summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public ValueTask<Result<T>> ValidateAsync(
         T? value,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) =>
+        ValidateAsync(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            cancellationToken,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified value with a fresh validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public ValueTask<Result<T>> ValidateAsync(
+        T? value,
+        ValidationTarget target,
+        CancellationToken cancellationToken = default,
         string? displayName = null
     ) =>
         ValidateAsync(
@@ -51,9 +73,7 @@ public abstract class AsyncValidator<T> : BaseValidator<T>
     /// <param name="value">The value to be validated.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
-    /// <param name="target">
-    /// The raw caller expression for the value. Will be used to automatically create the target of an error.
-    /// </param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
     /// <returns>The validation result.</returns>
     public async ValueTask<Result<T>> ValidateAsync(
@@ -61,6 +81,34 @@ public abstract class AsyncValidator<T> : BaseValidator<T>
         ValidationContext context,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) =>
+        FinalizeValidation(
+            context,
+            await ValidateChildValueAsync(
+                    value,
+                    context,
+                    cancellationToken,
+                    ValidationTarget.CallerExpression(target),
+                    displayName
+                )
+               .ConfigureAwait(false)
+        );
+
+    /// <summary>
+    /// Validates the specified value with the provided validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to be validated.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
+    /// <returns>The validation result.</returns>
+    public async ValueTask<Result<T>> ValidateAsync(
+        T? value,
+        ValidationContext context,
+        CancellationToken cancellationToken,
+        ValidationTarget target,
         string? displayName = null
     ) =>
         FinalizeValidation(
@@ -76,21 +124,42 @@ public abstract class AsyncValidator<T> : BaseValidator<T>
     /// <param name="value">The value to be validated.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
-    /// <param name="target">
-    /// The raw caller expression for the value. Will be used to automatically create the target of an error.
-    /// </param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
     /// <returns>A value task containing the validated and potentially normalized value.</returns>
-    public async ValueTask<ValidatedValue<T>> ValidateChildValueAsync(
+    public ValueTask<ValidatedValue<T>> ValidateChildValueAsync(
         T? value,
         ValidationContext context,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) => ValidateChildValueAsync(
+        value,
+        context,
+        cancellationToken,
+        ValidationTarget.CallerExpression(target),
+        displayName
+    );
+
+    /// <summary>
+    /// Validates the specified value with the provided validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to be validated.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
+    /// <returns>A value task containing the validated and potentially normalized value.</returns>
+    public async ValueTask<ValidatedValue<T>> ValidateChildValueAsync(
+        T? value,
+        ValidationContext context,
+        CancellationToken cancellationToken,
+        ValidationTarget target,
+        string? displayName = null
     )
     {
         ValidateCallArguments(context, target);
-        displayName ??= target;
+        displayName ??= target.Input;
         if (TryHandleAutomaticNull(value, context, target, displayName))
         {
             return ValidatedValue<T>.NoValue;
@@ -141,13 +210,35 @@ public abstract class AsyncValidator<TSource, TValidated> : BaseValidator<TSourc
     /// </summary>
     /// <param name="value">The source value.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public ValueTask<Result<TValidated>> ValidateAsync(
         TSource? value,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) =>
+        ValidateAsync(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            cancellationToken,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified source value with a fresh validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public ValueTask<Result<TValidated>> ValidateAsync(
+        TSource? value,
+        ValidationTarget target,
+        CancellationToken cancellationToken = default,
         string? displayName = null
     ) =>
         ValidateAsync(
@@ -164,7 +255,7 @@ public abstract class AsyncValidator<TSource, TValidated> : BaseValidator<TSourc
     /// <param name="value">The source value.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public async ValueTask<Result<TValidated>> ValidateAsync(
@@ -172,6 +263,34 @@ public abstract class AsyncValidator<TSource, TValidated> : BaseValidator<TSourc
         ValidationContext context,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) =>
+        FinalizeValidation(
+            context,
+            await ValidateChildValueAsync(
+                    value,
+                    context,
+                    cancellationToken,
+                    ValidationTarget.CallerExpression(target),
+                    displayName
+                )
+               .ConfigureAwait(false)
+        );
+
+    /// <summary>
+    /// Validates the specified source value with the provided validation context and transforms it into a validated output.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public async ValueTask<Result<TValidated>> ValidateAsync(
+        TSource? value,
+        ValidationContext context,
+        CancellationToken cancellationToken,
+        ValidationTarget target,
         string? displayName = null
     ) =>
         FinalizeValidation(
@@ -187,21 +306,42 @@ public abstract class AsyncValidator<TSource, TValidated> : BaseValidator<TSourc
     /// <param name="value">The value to be validated.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
-    /// <param name="target">
-    /// The raw caller expression for the value. Will be used to automatically create the target of an error.
-    /// </param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
     /// <returns>A value task containing the validated and potentially normalized value.</returns>
-    public async ValueTask<ValidatedValue<TValidated>> ValidateChildValueAsync(
+    public ValueTask<ValidatedValue<TValidated>> ValidateChildValueAsync(
         TSource? value,
         ValidationContext context,
         CancellationToken cancellationToken = default,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) => ValidateChildValueAsync(
+        value,
+        context,
+        cancellationToken,
+        ValidationTarget.CallerExpression(target),
+        displayName
+    );
+
+    /// <summary>
+    /// Validates the specified value with the provided validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to be validated.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="cancellationToken">The optional token to cancel the asynchronous operation.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
+    /// <returns>A value task containing the validated and potentially normalized value.</returns>
+    public async ValueTask<ValidatedValue<TValidated>> ValidateChildValueAsync(
+        TSource? value,
+        ValidationContext context,
+        CancellationToken cancellationToken,
+        ValidationTarget target,
+        string? displayName = null
     )
     {
         ValidateCallArguments(context, target);
-        displayName ??= target;
+        displayName ??= target.Input;
         if (TryHandleAutomaticNull(value, context, target, displayName))
         {
             return ValidatedValue<TValidated>.NoValue;

--- a/src/Light.PortableResults.Validation/BaseValidator.cs
+++ b/src/Light.PortableResults.Validation/BaseValidator.cs
@@ -42,13 +42,13 @@ public abstract class BaseValidator<TSource>
     /// </summary>
     /// <param name="value">The source value to inspect.</param>
     /// <param name="context">The active validation context.</param>
-    /// <param name="rawTarget">The raw caller expression for the source value.</param>
+    /// <param name="target">The target for the source value.</param>
     /// <param name="displayName">The display name for the value.</param>
     /// <returns><see langword="true" /> when an automatic null-validation error was added; otherwise, <see langword="false" />.</returns>
     protected bool TryHandleAutomaticNull(
         [NotNullWhen(false)] TSource? value,
         ValidationContext context,
-        string rawTarget,
+        ValidationTarget target,
         string displayName
     )
     {
@@ -57,7 +57,6 @@ public abstract class BaseValidator<TSource>
             return false;
         }
 
-        var target = context.GetAutomaticNullTarget(rawTarget);
         if (!context.TryCreateAutomaticNullError(value, target, displayName, out var error))
         {
             return false;
@@ -71,19 +70,21 @@ public abstract class BaseValidator<TSource>
     /// Validates the specified validation call arguments.
     /// </summary>
     /// <param name="context">The validation context.</param>
-    /// <param name="target">The raw caller expression target.</param>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="context" /> is the default instance.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target" /> is null.</exception>
-    protected static void ValidateCallArguments(ValidationContext context, string target)
+    /// <param name="target">The target descriptor.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="context" /> is the default instance or <paramref name="target" /> is the default
+    /// instance.
+    /// </exception>
+    protected static void ValidateCallArguments(ValidationContext context, ValidationTarget target)
     {
         if (context.IsDefault)
         {
             throw new ArgumentException("The validation context must not be the default instance.", nameof(context));
         }
 
-        if (target is null)
+        if (target.IsDefault)
         {
-            throw new ArgumentNullException(nameof(target));
+            throw new ArgumentException("The validation target must not be the default instance.", nameof(target));
         }
     }
 

--- a/src/Light.PortableResults.Validation/Check.cs
+++ b/src/Light.PortableResults.Validation/Check.cs
@@ -9,34 +9,42 @@ namespace Light.PortableResults.Validation;
 /// <typeparam name="T">The type of the value being validated.</typeparam>
 public readonly struct Check<T>
 {
+    private readonly string? _resolvedAbsoluteTarget;
+
     /// <summary>
     /// Initializes a new instance of <see cref="Check{T}" />.
     /// </summary>
     /// <param name="context">The validation context.</param>
-    /// <param name="target">The raw or normalized target.</param>
+    /// <param name="target">The target descriptor.</param>
     /// <param name="displayName">The human-readable display name.</param>
     /// <param name="value">The value being validated.</param>
-    /// <param name="isTargetNormalized">Indicates whether <paramref name="target" /> is already normalized.</param>
+    /// <param name="resolvedAbsoluteTarget">
+    /// The already-resolved absolute target, or <see langword="null" /> when it has not been materialized yet.
+    /// </param>
     /// <param name="isShortCircuited">Indicates whether further checks should be skipped.</param>
     /// <exception cref="InvalidOperationException">Thrown when <paramref name="context" /> is the default instance.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="target" /> or <paramref name="displayName" /> are <see langword="null" />.
-    /// </exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="target" /> is the default instance.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="displayName" /> is <see langword="null" />.</exception>
     public Check(
         ValidationContext context,
-        string target,
+        ValidationTarget target,
         string displayName,
         T value,
-        bool isTargetNormalized,
+        string? resolvedAbsoluteTarget,
         bool isShortCircuited
     )
     {
         context.ThrowIfDefault();
+        if (target.IsDefault)
+        {
+            throw new ArgumentException("The validation target must not be the default instance.", nameof(target));
+        }
+
         Context = context;
-        Target = target ?? throw new ArgumentNullException(nameof(target));
+        TargetDescriptor = target;
         DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
         Value = value;
-        IsTargetNormalized = isTargetNormalized;
+        _resolvedAbsoluteTarget = resolvedAbsoluteTarget;
         IsShortCircuited = isShortCircuited;
     }
 
@@ -46,9 +54,14 @@ public readonly struct Check<T>
     public ValidationContext Context { get; }
 
     /// <summary>
-    /// Gets the raw or normalized target path.
+    /// Gets the explicit target descriptor supplied when the check was created.
     /// </summary>
-    public string Target { get; }
+    public ValidationTarget TargetDescriptor { get; }
+
+    /// <summary>
+    /// Gets the original target input or the resolved absolute target once it has been materialized.
+    /// </summary>
+    public string Target => _resolvedAbsoluteTarget ?? TargetDescriptor.Input;
 
     /// <summary>
     /// Gets the display name for the current value.
@@ -59,11 +72,6 @@ public readonly struct Check<T>
     /// Gets the current value.
     /// </summary>
     public T Value { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the target path has already been normalized.
-    /// </summary>
-    public bool IsTargetNormalized { get; }
 
     /// <summary>
     /// Gets a value indicating whether subsequent checks should be skipped.
@@ -81,7 +89,7 @@ public readonly struct Check<T>
     /// <param name="value">The new value.</param>
     /// <returns>The updated check.</returns>
     public Check<T> WithValue(T value) =>
-        new (Context, Target, DisplayName, value, IsTargetNormalized, IsShortCircuited);
+        new (Context, TargetDescriptor, DisplayName, value, _resolvedAbsoluteTarget, IsShortCircuited);
 
     /// <summary>
     /// Creates a new check with a different display name.
@@ -91,10 +99,10 @@ public readonly struct Check<T>
     public Check<T> WithDisplayName(string displayName) =>
         new (
             Context,
-            Target,
+            TargetDescriptor,
             displayName ?? throw new ArgumentNullException(nameof(displayName)),
             Value,
-            IsTargetNormalized,
+            _resolvedAbsoluteTarget,
             IsShortCircuited
         );
 
@@ -102,7 +110,8 @@ public readonly struct Check<T>
     /// Creates a new short-circuited check.
     /// </summary>
     /// <returns>The updated check.</returns>
-    public Check<T> ShortCircuit() => new (Context, Target, DisplayName, Value, IsTargetNormalized, true);
+    public Check<T> ShortCircuit() =>
+        new (Context, TargetDescriptor, DisplayName, Value, _resolvedAbsoluteTarget, true);
 
     /// <summary>
     /// Creates a new short-circuited check if requested.
@@ -113,30 +122,29 @@ public readonly struct Check<T>
         shortCircuitOnError ? ShortCircuit() : this;
 
     /// <summary>
-    /// Normalizes the target if necessary.
+    /// Resolves the target to an absolute path if necessary.
     /// </summary>
-    /// <returns>The normalized check.</returns>
+    /// <returns>The check with a resolved absolute target.</returns>
     public Check<T> NormalizeTargetIfNecessary()
     {
-        if (IsTargetNormalized)
+        if (_resolvedAbsoluteTarget is not null)
         {
             return this;
         }
 
-        var normalizedTarget = Context.NormalizeTarget(Target);
-        var resolvedTarget = ResolveAbsoluteTarget(normalizedTarget);
-        var displayName = string.Equals(DisplayName, Target, StringComparison.Ordinal) ? resolvedTarget : DisplayName;
-        return new Check<T>(Context, resolvedTarget, displayName, Value, isTargetNormalized: true, IsShortCircuited);
+        var resolvedTarget = Context.ResolveTarget(TargetDescriptor);
+        var displayName = string.Equals(DisplayName, TargetDescriptor.Input, StringComparison.Ordinal) ?
+            resolvedTarget :
+            DisplayName;
+        return new Check<T>(Context, TargetDescriptor, displayName, Value, resolvedTarget, IsShortCircuited);
     }
 
     /// <summary>
     /// Creates a child validation context for the current check target.
-    /// Already-normalized targets that are already absolute within the current scope are reused without adding the
-    /// current scope prefix again.
     /// </summary>
     /// <returns>The child validation context.</returns>
     public ValidationContext CreateChildContext() =>
-        Context.ForMember(GetChildContextTarget(), isNormalized: true);
+        Context.ForAbsolute(GetResolvedAbsoluteTarget(), isNormalized: true);
 
     /// <summary>
     /// Creates a child validation context for the specified member below the current check target.
@@ -148,7 +156,7 @@ public readonly struct Check<T>
     /// </param>
     /// <returns>The child validation context.</returns>
     public ValidationContext CreateChildContextForMember(string memberName, bool isNormalized = false) =>
-        CreateChildContext().ForMember(memberName, isNormalized);
+        CreateChildContext().ForRelative(memberName, isNormalized);
 
     /// <summary>
     /// Creates a child validation context for the specified collection index below the current check target.
@@ -167,7 +175,7 @@ public readonly struct Check<T>
         var normalizedCheck = NormalizeTargetIfNecessary();
         return normalizedCheck.Context.CreateAbsoluteMessageContext(
             normalizedCheck.Value,
-            normalizedCheck.Target,
+            normalizedCheck.GetResolvedAbsoluteTarget(),
             normalizedCheck.DisplayName
         );
     }
@@ -190,7 +198,7 @@ public readonly struct Check<T>
         var normalizedCheck = NormalizeTargetIfNecessary();
         if (error.Target is null)
         {
-            error = error with { Target = normalizedCheck.Target };
+            error = error with { Target = normalizedCheck.GetResolvedAbsoluteTarget() };
         }
 
         normalizedCheck.Context.AddError(error);
@@ -204,7 +212,8 @@ public readonly struct Check<T>
     /// <param name="code">The optional error code.</param>
     /// <param name="metadata">The optional metadata.</param>
     /// <param name="target">
-    /// The optional explicit normalized target, composed relative to the current context.
+    /// The optional explicit target. Relative targets are composed with the current validation scope, absolute targets
+    /// are used unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="category">The error category.</param>
     /// <param name="respectShortCircuit">
@@ -215,7 +224,7 @@ public readonly struct Check<T>
         ValidationErrorMessage message,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory category = ErrorCategory.Validation,
         bool respectShortCircuit = true
     )
@@ -227,8 +236,8 @@ public readonly struct Check<T>
 
         var normalizedCheck = NormalizeTargetIfNecessary();
         var resolvedTarget = target is null ?
-            normalizedCheck.Target :
-            normalizedCheck.Context.ComposeTarget(target, isTargetNormalized: true);
+            normalizedCheck.GetResolvedAbsoluteTarget() :
+            normalizedCheck.Context.ResolveTarget(target.Value);
         normalizedCheck.Context.AddError(
             message.ToError(code, resolvedTarget, category, metadata)
         );
@@ -242,7 +251,8 @@ public readonly struct Check<T>
     /// <param name="code">The optional override for the definition's default code.</param>
     /// <param name="metadata">The optional override for the definition's default metadata.</param>
     /// <param name="target">
-    /// The optional override normalized target, composed relative to the current context.
+    /// The optional override target. Relative targets are composed with the current validation scope, absolute targets
+    /// are used unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="category">The optional override for the definition's default category.</param>
     /// <param name="respectShortCircuit">
@@ -253,7 +263,7 @@ public readonly struct Check<T>
         ValidationErrorDefinition definition,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory? category = null,
         bool respectShortCircuit = true
     )
@@ -290,7 +300,8 @@ public readonly struct Check<T>
     /// <param name="code">The optional error code.</param>
     /// <param name="metadata">The optional metadata.</param>
     /// <param name="target">
-    /// The optional explicit normalized target, composed relative to the current context.
+    /// The optional explicit target. Relative targets are composed with the current validation scope, absolute targets
+    /// are used unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="respectShortCircuit">
     /// When <see langword="true" />, the error is skipped for short-circuited checks. The default is <see langword="true" />.
@@ -300,7 +311,7 @@ public readonly struct Check<T>
         IValidationErrorMessageTemplate template,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         bool respectShortCircuit = true
     )
     {
@@ -335,7 +346,8 @@ public readonly struct Check<T>
     /// <param name="code">The optional error code.</param>
     /// <param name="metadata">The optional metadata.</param>
     /// <param name="target">
-    /// The optional explicit normalized target, composed relative to the current context.
+    /// The optional explicit target. Relative targets are composed with the current validation scope, absolute targets
+    /// are used unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="respectShortCircuit">
     /// When <see langword="true" />, the error is skipped for short-circuited checks. The default is <see langword="true" />.
@@ -346,7 +358,7 @@ public readonly struct Check<T>
         TParameter parameter,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         bool respectShortCircuit = true
     )
     {
@@ -379,7 +391,8 @@ public readonly struct Check<T>
     /// <param name="code">The optional error code.</param>
     /// <param name="metadata">The optional metadata.</param>
     /// <param name="target">
-    /// The optional explicit normalized target, composed relative to the current context.
+    /// The optional explicit target. Relative targets are composed with the current validation scope, absolute targets
+    /// are used unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="respectShortCircuit">
     /// When <see langword="true" />, the error is skipped for short-circuited checks. The default is <see langword="true" />.
@@ -389,7 +402,7 @@ public readonly struct Check<T>
         string message,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         bool respectShortCircuit = true
     ) =>
         AddError(
@@ -407,98 +420,24 @@ public readonly struct Check<T>
     /// <param name="check">The check to convert.</param>
     public static implicit operator T(Check<T> check) => check.Value;
 
+    internal ValidationTarget GetResolvedAbsoluteTargetDescriptor() =>
+        ValidationTarget.Absolute(GetResolvedAbsoluteTarget(), isNormalized: true);
+
     private static string ResolveDefinitionTarget(
         Check<T> normalizedCheck,
-        string? definitionTarget,
-        string? overrideTarget
+        ValidationTarget? definitionTarget,
+        ValidationTarget? overrideTarget
     )
     {
         if (overrideTarget is not null)
         {
-            return normalizedCheck.Context.ComposeTarget(overrideTarget, isTargetNormalized: true);
+            return normalizedCheck.Context.ResolveTarget(overrideTarget.Value);
         }
 
-        return definitionTarget ?? normalizedCheck.Target;
+        return definitionTarget is not null ?
+            normalizedCheck.Context.ResolveTarget(definitionTarget.Value) :
+            normalizedCheck.GetResolvedAbsoluteTarget();
     }
 
-    private string GetChildContextTarget()
-    {
-        var normalizedTarget = IsTargetNormalized ? Target : ResolveAbsoluteTarget(Context.NormalizeTarget(Target));
-        var targetPrefix = Context.TargetPrefix;
-        if (targetPrefix.Length == 0 || normalizedTarget.Length == 0)
-        {
-            return normalizedTarget;
-        }
-
-        if (string.Equals(normalizedTarget, targetPrefix, StringComparison.Ordinal))
-        {
-            return string.Empty;
-        }
-
-        if (normalizedTarget.Length > targetPrefix.Length &&
-            string.Compare(
-                normalizedTarget,
-                0,
-                targetPrefix,
-                0,
-                targetPrefix.Length,
-                StringComparison.Ordinal
-            ) ==
-            0
-           )
-        {
-            var separator = normalizedTarget[targetPrefix.Length];
-            if (separator == '.')
-            {
-                return normalizedTarget.Substring(targetPrefix.Length + 1);
-            }
-
-            if (separator == '[')
-            {
-                return normalizedTarget.Substring(targetPrefix.Length);
-            }
-        }
-
-        return normalizedTarget;
-    }
-
-    private string ResolveAbsoluteTarget(string normalizedTarget)
-    {
-        var targetPrefix = Context.TargetPrefix;
-        if (targetPrefix.Length == 0)
-        {
-            return normalizedTarget;
-        }
-
-        if (normalizedTarget.Length == 0)
-        {
-            return targetPrefix;
-        }
-
-        if (string.Equals(normalizedTarget, targetPrefix, StringComparison.Ordinal))
-        {
-            return normalizedTarget;
-        }
-
-        if (normalizedTarget.Length > targetPrefix.Length &&
-            string.Compare(
-                normalizedTarget,
-                0,
-                targetPrefix,
-                0,
-                targetPrefix.Length,
-                StringComparison.Ordinal
-            ) ==
-            0
-           )
-        {
-            var separator = normalizedTarget[targetPrefix.Length];
-            if (separator is '.' or '[')
-            {
-                return normalizedTarget;
-            }
-        }
-
-        return ValidationTargets.Compose(targetPrefix, normalizedTarget);
-    }
+    private string GetResolvedAbsoluteTarget() => _resolvedAbsoluteTarget ?? Context.ResolveTarget(TargetDescriptor);
 }

--- a/src/Light.PortableResults.Validation/CheckExtensions.cs
+++ b/src/Light.PortableResults.Validation/CheckExtensions.cs
@@ -37,7 +37,7 @@ public static class CheckExtensions
         return childValidator.ValidateChildValue(
             check.Value,
             check.CreateChildContext(),
-            check.Target,
+            check.GetResolvedAbsoluteTargetDescriptor(),
             check.DisplayName
         );
     }
@@ -69,7 +69,7 @@ public static class CheckExtensions
         return childValidator.ValidateChildValue(
             check.Value,
             check.CreateChildContext(),
-            check.Target,
+            check.GetResolvedAbsoluteTargetDescriptor(),
             check.DisplayName
         );
     }
@@ -103,7 +103,7 @@ public static class CheckExtensions
             check.Value,
             check.CreateChildContext(),
             cancellationToken,
-            check.Target,
+            check.GetResolvedAbsoluteTargetDescriptor(),
             check.DisplayName
         );
     }
@@ -139,7 +139,7 @@ public static class CheckExtensions
             check.Value,
             check.CreateChildContext(),
             cancellationToken,
-            check.Target,
+            check.GetResolvedAbsoluteTargetDescriptor(),
             check.DisplayName
         );
     }
@@ -180,7 +180,7 @@ public static class CheckExtensions
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
@@ -226,7 +226,7 @@ public static class CheckExtensions
             _ = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
         }
@@ -264,7 +264,7 @@ public static class CheckExtensions
             _ = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
         }
@@ -387,7 +387,7 @@ public static class CheckExtensions
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
@@ -434,7 +434,7 @@ public static class CheckExtensions
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
@@ -478,7 +478,7 @@ public static class CheckExtensions
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
-                target: string.Empty,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
@@ -533,7 +533,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -584,7 +584,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -627,7 +627,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -763,7 +763,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -816,7 +816,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -867,7 +867,7 @@ public static class CheckExtensions
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
-                    target: string.Empty,
+                    ValidationTarget.Relative(string.Empty, isNormalized: true),
                     displayName: CreateIndexedDisplayName(check, i)
                 )
                .ConfigureAwait(false);
@@ -902,7 +902,11 @@ public static class CheckExtensions
 
     private static Check<TItem> CreateItemCheck<TCollection, TItem>(Check<TCollection> check, TItem item, int index) =>
         check.CreateChildContextForIndex(index)
-           .Check(item, target: string.Empty, displayName: CreateIndexedDisplayName(check, index));
+           .Check(
+                item,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
+                displayName: CreateIndexedDisplayName(check, index)
+            );
 
     private static string CreateIndexedDisplayName<TCollection>(Check<TCollection> check, int index) =>
         check.DisplayName.Length == 0 ? $"[{index}]" : $"{check.DisplayName}[{index}]";

--- a/src/Light.PortableResults.Validation/DefaultValidationTargetNormalizer.cs
+++ b/src/Light.PortableResults.Validation/DefaultValidationTargetNormalizer.cs
@@ -5,10 +5,7 @@ using System.Collections.Concurrent;
 namespace Light.PortableResults.Validation;
 
 /// <summary>
-/// The built-in validation target normalizer for raw caller-expression paths.
-/// It preserves member paths, removes the leading parameter root when present, and applies a configurable casing
-/// convention to member segments.
-/// Already normalized absolute targets should usually not be passed to this normalizer again.
+/// The built-in validation target normalizer for caller-expression, relative, and absolute validation targets.
 /// </summary>
 public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormalizer
 {
@@ -18,8 +15,8 @@ public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormali
     public const int DefaultStackBufferThreshold = 512;
 
     private readonly ArrayPool<char> _arrayPool;
-    private readonly ConcurrentDictionary<string, string> _cache = new (StringComparer.Ordinal);
-    private readonly Func<string, string> _normalizeDelegate;
+    private readonly ConcurrentDictionary<string, string> _callerExpressionCache = new (StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _pathCache = new (StringComparer.Ordinal);
 
     /// <summary>
     /// Initializes a new instance of <see cref="DefaultValidationTargetNormalizer" />.
@@ -47,7 +44,6 @@ public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormali
         Casing = casing;
         _arrayPool = arrayPool ?? ArrayPool<char>.Shared;
         ArrayPoolThreshold = arrayPoolThreshold;
-        _normalizeDelegate = NormalizeCore;
     }
 
     /// <summary>
@@ -61,12 +57,29 @@ public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormali
     public int ArrayPoolThreshold { get; }
 
     /// <inheritdoc />
-    public string Normalize(string rawPath) =>
-        rawPath is null ?
-            throw new ArgumentNullException(nameof(rawPath)) :
-            _cache.GetOrAdd(rawPath, _normalizeDelegate);
+    public string Normalize(string rawPath, ValidationTargetSemantics semantics)
+    {
+        if (rawPath is null)
+        {
+            throw new ArgumentNullException(nameof(rawPath));
+        }
 
-    private string NormalizeCore(string rawPath)
+        if (!semantics.IsDefined())
+        {
+            throw new ArgumentOutOfRangeException(nameof(semantics));
+        }
+
+        return semantics == ValidationTargetSemantics.CallerExpression ?
+            _callerExpressionCache.GetOrAdd(rawPath, NormalizeCallerExpressionCore) :
+            _pathCache.GetOrAdd(rawPath, NormalizePathCore);
+    }
+
+    private string NormalizeCallerExpressionCore(string rawPath) =>
+        NormalizeCore(rawPath, ValidationTargetSemantics.CallerExpression);
+
+    private string NormalizePathCore(string rawPath) => NormalizeCore(rawPath, ValidationTargetSemantics.Relative);
+
+    private string NormalizeCore(string rawPath, ValidationTargetSemantics semantics)
     {
         var trimmedPath = rawPath.AsSpan().Trim();
         if (trimmedPath.IsEmpty)
@@ -74,7 +87,9 @@ public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormali
             return string.Empty;
         }
 
-        var parsingStart = FindParsingStart(trimmedPath);
+        var parsingStart = semantics == ValidationTargetSemantics.CallerExpression ?
+            FindCallerExpressionParsingStart(trimmedPath) :
+            0;
         if (parsingStart >= trimmedPath.Length)
         {
             return string.Empty;
@@ -97,7 +112,7 @@ public sealed class DefaultValidationTargetNormalizer : IValidationTargetNormali
         }
     }
 
-    private static int FindParsingStart(ReadOnlySpan<char> rawPath)
+    private static int FindCallerExpressionParsingStart(ReadOnlySpan<char> rawPath)
     {
         var indexOfDot = rawPath.IndexOf('.');
         return indexOfDot == -1 ? 0 : indexOfDot + 1;

--- a/src/Light.PortableResults.Validation/IValidationTargetNormalizer.cs
+++ b/src/Light.PortableResults.Validation/IValidationTargetNormalizer.cs
@@ -3,19 +3,19 @@ using System;
 namespace Light.PortableResults.Validation;
 
 /// <summary>
-/// Normalizes raw caller-expression target paths into the flat member path format used by Light.PortableResults.
+/// Normalizes validation targets into the flat member path format used by Light.PortableResults.
 /// </summary>
 public interface IValidationTargetNormalizer
 {
     /// <summary>
-    /// Normalizes the specified raw caller-expression path.
+    /// Normalizes the specified target path according to the provided semantics.
     /// </summary>
-    /// <param name="rawPath">
-    /// The raw caller-expression path to normalize, such as <c>dto.Address.ZipCode</c>.
-    /// Already normalized absolute targets such as <c>address.zipCode</c> should usually be passed through unchanged
-    /// by the caller instead of being normalized again.
-    /// </param>
+    /// <param name="rawPath">The raw target input to normalize.</param>
+    /// <param name="semantics">The semantics used to interpret <paramref name="rawPath" />.</param>
     /// <returns>The normalized target path.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="rawPath" /> is <see langword="null" />.</exception>
-    string Normalize(string rawPath);
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="semantics" /> is not a supported <see cref="ValidationTargetSemantics" /> value.
+    /// </exception>
+    string Normalize(string rawPath, ValidationTargetSemantics semantics);
 }

--- a/src/Light.PortableResults.Validation/ValidationContext.cs
+++ b/src/Light.PortableResults.Validation/ValidationContext.cs
@@ -135,7 +135,18 @@ public readonly struct ValidationContext
     /// <param name="target">The raw caller expression for the child value.</param>
     /// <returns>The scoped validation context.</returns>
     public ValidationContext For<T>(T child, [CallerArgumentExpression("child")] string target = "") =>
-        WithPrefix(target);
+        ForCallerExpression(target);
+
+    /// <summary>
+    /// Creates a scoped validation context from a caller-expression-style target.
+    /// </summary>
+    /// <param name="target">The caller-expression-style target.</param>
+    /// <param name="isNormalized">
+    /// <see langword="true" /> when <paramref name="target" /> is already normalized for caller-expression semantics.
+    /// </param>
+    /// <returns>The scoped validation context.</returns>
+    public ValidationContext ForCallerExpression(string target, bool isNormalized = false) =>
+        ForTarget(ValidationTarget.CallerExpression(target, isNormalized));
 
     /// <summary>
     /// Creates a scoped validation context for the specified member path segment.
@@ -146,7 +157,45 @@ public readonly struct ValidationContext
     /// </param>
     /// <returns>The scoped validation context.</returns>
     public ValidationContext ForMember(string memberName, bool isNormalized = false) =>
-        WithPrefix(memberName, isNormalized);
+        ForRelative(memberName, isNormalized);
+
+    /// <summary>
+    /// Creates a scoped validation context for a target path relative to the current validation scope.
+    /// </summary>
+    /// <param name="target">The relative target path.</param>
+    /// <param name="isNormalized">
+    /// <see langword="true" /> when <paramref name="target" /> is already normalized; otherwise, <see langword="false" />.
+    /// </param>
+    /// <returns>The scoped validation context.</returns>
+    public ValidationContext ForRelative(string target, bool isNormalized = false) =>
+        ForTarget(ValidationTarget.Relative(target, isNormalized));
+
+    /// <summary>
+    /// Creates a scoped validation context from an absolute target path.
+    /// </summary>
+    /// <param name="target">The absolute target path.</param>
+    /// <param name="isNormalized">
+    /// <see langword="true" /> when <paramref name="target" /> is already normalized; otherwise, <see langword="false" />.
+    /// </param>
+    /// <returns>The scoped validation context.</returns>
+    public ValidationContext ForAbsolute(string target, bool isNormalized = false) =>
+        ForTarget(ValidationTarget.Absolute(target, isNormalized));
+
+    /// <summary>
+    /// Creates a scoped validation context from an explicit validation target descriptor.
+    /// </summary>
+    /// <param name="target">The target descriptor.</param>
+    /// <returns>The scoped validation context.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="target" /> is the default instance.</exception>
+    public ValidationContext ForTarget(ValidationTarget target)
+    {
+        EnsureInitialized();
+
+        var resolvedTarget = ResolveTarget(target);
+        return string.Equals(resolvedTarget, _targetPrefix, StringComparison.Ordinal) ?
+            this :
+            new ValidationContext(State, resolvedTarget);
+    }
 
     /// <summary>
     /// Creates a scoped validation context for the specified collection index.
@@ -160,40 +209,24 @@ public readonly struct ValidationContext
     }
 
     /// <summary>
-    /// Creates a scoped validation context with the specified target prefix.
+    /// Creates a scoped validation context with the specified relative target prefix.
     /// </summary>
-    /// <param name="prefix">The prefix to append to this scope.</param>
+    /// <param name="prefix">The relative prefix to append to this scope.</param>
     /// <param name="isNormalized">
     /// <see langword="true" /> when <paramref name="prefix" /> is already normalized; otherwise, <see langword="false" />.
     /// </param>
     /// <returns>The scoped validation context.</returns>
-    public ValidationContext WithPrefix(string prefix, bool isNormalized = false)
-    {
-        EnsureInitialized();
-        if (prefix is null)
-        {
-            throw new ArgumentNullException(nameof(prefix));
-        }
-
-        if (prefix.Length == 0)
-        {
-            return this;
-        }
-
-        var normalizedPrefix = isNormalized ? prefix : NormalizeTarget(prefix);
-        var composedPrefix = ValidationTargets.Compose(_targetPrefix, normalizedPrefix);
-        return new ValidationContext(State, composedPrefix);
-    }
+    public ValidationContext WithPrefix(string prefix, bool isNormalized = false) => ForRelative(prefix, isNormalized);
 
     /// <summary>
-    /// Creates a check for the specified value and raw caller expression target.
+    /// Creates a check for the specified value and caller-expression target.
     /// </summary>
     /// <typeparam name="T">The type of the value to validate.</typeparam>
     /// <param name="value">The value to validate.</param>
     /// <param name="stringValueNormalizer">
     /// Overrides the context-wide string normalization behavior for this specific check when set.
     /// </param>
-    /// <param name="target">The raw target expression.</param>
+    /// <param name="target">The caller-expression-style target.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The created check.</returns>
     /// <exception cref="InvalidOperationException">Thrown when this context is the default instance.</exception>
@@ -206,16 +239,49 @@ public readonly struct ValidationContext
     )
     {
         EnsureInitialized();
-        // ReSharper disable once JoinNullCheckWithUsage -- false positive, for display name, we use the ??= operator.
-        // This would mean that the null check for target is only executed when displayName is null.
         if (target is null)
         {
             throw new ArgumentNullException(nameof(target));
         }
 
-        displayName ??= target;
+        return Check(
+            value,
+            ValidationTarget.CallerExpression(target),
+            stringValueNormalizer,
+            displayName
+        );
+    }
+
+    /// <summary>
+    /// Creates a check for the specified value and explicit validation target descriptor.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to validate.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="stringValueNormalizer">
+    /// Overrides the context-wide string normalization behavior for this specific check when set.
+    /// </param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The created check.</returns>
+    public Check<T> Check<T>(
+        T value,
+        ValidationTarget target,
+        IStringValueNormalizer? stringValueNormalizer = null,
+        string? displayName = null
+    )
+    {
+        EnsureInitialized();
+        var validatedTarget = EnsureTarget(target, nameof(target));
+        displayName ??= validatedTarget.Input;
         value = NormalizeValueIfNecessary(value, stringValueNormalizer ?? Options.StringValueNormalizer);
-        return new Check<T>(this, target, displayName, value, isTargetNormalized: false, isShortCircuited: false);
+        return new Check<T>(
+            this,
+            validatedTarget,
+            displayName,
+            value,
+            resolvedAbsoluteTarget: null,
+            isShortCircuited: false
+        );
     }
 
     /// <summary>
@@ -242,18 +308,19 @@ public readonly struct ValidationContext
     /// <param name="message">The generated validation error message.</param>
     /// <param name="code">The optional error code.</param>
     /// <param name="target">
-    /// The optional normalized target path, composed relative to this context.
+    /// The optional validation target. Relative targets are composed with the current scope, absolute targets are used
+    /// unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="metadata">The optional error metadata.</param>
     public void AddError(
         ValidationErrorMessage message,
         string? code = null,
-        string? target = null,
+        ValidationTarget? target = null,
         MetadataObject? metadata = null
     )
     {
         EnsureInitialized();
-        var resolvedTarget = target is null ? _targetPrefix : ComposeTarget(target, isTargetNormalized: true);
+        var resolvedTarget = target is null ? _targetPrefix : ResolveTarget(target.Value);
         AddError(message.ToError(code, resolvedTarget, ErrorCategory.Validation, metadata));
     }
 
@@ -263,12 +330,18 @@ public readonly struct ValidationContext
     /// <param name="message">The error message.</param>
     /// <param name="code">The optional error code.</param>
     /// <param name="target">
-    /// The optional normalized target path, composed relative to this context.
+    /// The optional validation target. Relative targets are composed with the current scope, absolute targets are used
+    /// unchanged, and caller-expression targets are normalized before composition.
     /// </param>
     /// <param name="metadata">The optional error metadata.</param>
     /// <exception cref="InvalidOperationException">Thrown when this context is the default instance.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="message" /> is null.</exception>
-    public void AddError(string message, string? code = null, string? target = null, MetadataObject? metadata = null)
+    public void AddError(
+        string message,
+        string? code = null,
+        ValidationTarget? target = null,
+        MetadataObject? metadata = null
+    )
     {
         EnsureInitialized();
         if (message is null)
@@ -280,15 +353,57 @@ public readonly struct ValidationContext
     }
 
     /// <summary>
-    /// Normalizes a raw target expression using the configured target normalizer.
+    /// Normalizes the specified caller-expression target.
     /// </summary>
-    /// <param name="rawTarget">The raw target expression.</param>
+    /// <param name="target">The caller-expression target.</param>
     /// <returns>The normalized target.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when this context is the default instance.</exception>
-    public string NormalizeTarget(string rawTarget)
+    public string NormalizeCallerExpression(string target)
     {
         EnsureInitialized();
-        return Options.TargetNormalizer.Normalize(rawTarget);
+        return Options.TargetNormalizer.Normalize(target, ValidationTargetSemantics.CallerExpression);
+    }
+
+    /// <summary>
+    /// Normalizes the specified direct validation path without applying caller-expression rules.
+    /// </summary>
+    /// <param name="target">The direct validation path.</param>
+    /// <returns>The normalized path.</returns>
+    public string NormalizePath(string target)
+    {
+        EnsureInitialized();
+        return Options.TargetNormalizer.Normalize(target, ValidationTargetSemantics.Relative);
+    }
+
+    /// <summary>
+    /// Normalizes the specified validation target according to its explicit semantics.
+    /// </summary>
+    /// <param name="target">The target descriptor.</param>
+    /// <returns>The normalized target.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="target" /> is the default instance.</exception>
+    public string NormalizeTarget(ValidationTarget target)
+    {
+        EnsureInitialized();
+        var validatedTarget = EnsureTarget(target, nameof(target));
+        return validatedTarget.IsNormalized ?
+            validatedTarget.Input :
+            Options.TargetNormalizer.Normalize(validatedTarget.Input, validatedTarget.Semantics);
+    }
+
+    /// <summary>
+    /// Resolves the specified validation target to an absolute flat validation path.
+    /// </summary>
+    /// <param name="target">The target descriptor.</param>
+    /// <returns>The resolved absolute target.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="target" /> is the default instance.</exception>
+    public string ResolveTarget(ValidationTarget target)
+    {
+        EnsureInitialized();
+        var validatedTarget = EnsureTarget(target, nameof(target));
+        var normalizedTarget = NormalizeTarget(validatedTarget);
+
+        return validatedTarget.Semantics == ValidationTargetSemantics.Absolute ?
+            normalizedTarget :
+            ValidationTargets.Compose(_targetPrefix, normalizedTarget);
     }
 
     /// <summary>
@@ -308,24 +423,20 @@ public readonly struct ValidationContext
     /// </summary>
     /// <typeparam name="T">The validated value type.</typeparam>
     /// <param name="value">The validated value.</param>
-    /// <param name="target">The normalized validation target.</param>
+    /// <param name="target">The target that identifies the validated value.</param>
     /// <param name="displayName">The display name.</param>
     /// <param name="error">The created error when one should be produced.</param>
     /// <returns><see langword="true" /> when an error was created; otherwise, <see langword="false" />.</returns>
-    public bool TryCreateAutomaticNullError<T>(T value, string target, string displayName, out Error error)
+    public bool TryCreateAutomaticNullError<T>(T value, ValidationTarget target, string displayName, out Error error)
     {
         EnsureInitialized();
-        if (target is null)
-        {
-            throw new ArgumentNullException(nameof(target));
-        }
-
         if (displayName is null)
         {
             throw new ArgumentNullException(nameof(displayName));
         }
 
-        var messageContext = CreateAbsoluteMessageContext(value, target, displayName);
+        var resolvedTarget = GetAutomaticNullTarget(target);
+        var messageContext = CreateAbsoluteMessageContext(value, resolvedTarget, displayName);
         return Options.AutomaticNullErrorProvider.TryCreateError(in messageContext, out error);
     }
 
@@ -365,56 +476,23 @@ public readonly struct ValidationContext
     }
 
     /// <summary>
-    /// Gets the target path for the automatic null check.
+    /// Gets the absolute target path to use when the validated value is <see langword="null" />.
     /// </summary>
-    /// <param name="rawTarget">The non-normalized target path.</param>
-    /// <returns>The normalized flat target.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when this context is the default instance.</exception>
-    public string GetAutomaticNullTarget(string rawTarget)
+    /// <param name="target">The target descriptor for the validated value.</param>
+    /// <returns>The absolute target path.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="target" /> is the default instance.</exception>
+    public string GetAutomaticNullTarget(ValidationTarget target)
     {
         EnsureInitialized();
-        if (_targetPrefix.Length > 0)
+        var validatedTarget = EnsureTarget(target, nameof(target));
+        if (validatedTarget.Semantics == ValidationTargetSemantics.CallerExpression &&
+            ValidationTargets.IsSimpleIdentifier(NormalizeTarget(validatedTarget))
+           )
         {
-            if (ValidationTargets.IsSimpleIdentifier(rawTarget))
-            {
-                return _targetPrefix;
-            }
-
-            var normalizedTarget = NormalizeTarget(rawTarget);
-            if (string.Equals(normalizedTarget, _targetPrefix, StringComparison.Ordinal))
-            {
-                return _targetPrefix;
-            }
+            return _targetPrefix;
         }
 
-        if (_targetPrefix.Length == 0 && ValidationTargets.IsSimpleIdentifier(rawTarget))
-        {
-            return string.Empty;
-        }
-
-        return ComposeTarget(rawTarget, isTargetNormalized: false);
-    }
-
-    /// <summary>
-    /// Composes a target path by combining the context's target prefix with the specified target.
-    /// </summary>
-    /// <param name="target">The target to compose with the prefix.</param>
-    /// <param name="isTargetNormalized">
-    /// <see langword="true" /> when <paramref name="target" /> is already normalized; otherwise, <see langword="false" />.
-    /// </param>
-    /// <returns>The composed target path.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when this context is the default instance.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target" /> is null.</exception>
-    public string ComposeTarget(string target, bool isTargetNormalized)
-    {
-        EnsureInitialized();
-        if (target is null)
-        {
-            throw new ArgumentNullException(nameof(target));
-        }
-
-        var normalizedTarget = isTargetNormalized ? target : NormalizeTarget(target);
-        return ValidationTargets.Compose(_targetPrefix, normalizedTarget);
+        return ResolveTarget(validatedTarget);
     }
 
     /// <summary>
@@ -430,6 +508,16 @@ public readonly struct ValidationContext
     {
         EnsureInitialized();
         return new ValidationErrorMessageContext<T>(AsReadOnly(), displayName, target, value);
+    }
+
+    private static ValidationTarget EnsureTarget(ValidationTarget target, string paramName)
+    {
+        if (target.IsDefault)
+        {
+            throw new ArgumentException("The validation target must not be the default instance.", paramName);
+        }
+
+        return target;
     }
 
     private static T NormalizeValueIfNecessary<T>(T value, IStringValueNormalizer normalizer)

--- a/src/Light.PortableResults.Validation/ValidationErrorDefinition.cs
+++ b/src/Light.PortableResults.Validation/ValidationErrorDefinition.cs
@@ -13,12 +13,12 @@ public abstract class ValidationErrorDefinition
     /// </summary>
     /// <param name="code">The default error code.</param>
     /// <param name="metadata">The default error metadata.</param>
-    /// <param name="target">The default absolute error target.</param>
+    /// <param name="target">The default error target.</param>
     /// <param name="category">The default error category.</param>
     protected ValidationErrorDefinition(
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory category = ErrorCategory.Validation
     )
     {
@@ -39,9 +39,9 @@ public abstract class ValidationErrorDefinition
     public MetadataObject? Metadata { get; }
 
     /// <summary>
-    /// Gets the default absolute error target.
+    /// Gets the default error target.
     /// </summary>
-    public string? Target { get; }
+    public ValidationTarget? Target { get; }
 
     /// <summary>
     /// Gets the default error category.
@@ -69,13 +69,13 @@ public abstract class ValidationErrorDefinition<TParameter> : ValidationErrorDef
     /// <param name="parameter">The fixed rule parameter.</param>
     /// <param name="code">The default error code.</param>
     /// <param name="metadata">The default error metadata.</param>
-    /// <param name="target">The default absolute error target.</param>
+    /// <param name="target">The default error target.</param>
     /// <param name="category">The default error category.</param>
     protected ValidationErrorDefinition(
         TParameter parameter,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory category = ErrorCategory.Validation
     )
         : base(code, metadata, target, category)
@@ -100,13 +100,13 @@ public class TemplateValidationErrorDefinition : ValidationErrorDefinition
     /// <param name="template">The reusable message template.</param>
     /// <param name="code">The default error code.</param>
     /// <param name="metadata">The default error metadata.</param>
-    /// <param name="target">The default absolute error target.</param>
+    /// <param name="target">The default error target.</param>
     /// <param name="category">The default error category.</param>
     public TemplateValidationErrorDefinition(
         IValidationErrorMessageTemplate template,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory category = ErrorCategory.Validation
     )
         : base(code, metadata, target, category)
@@ -137,14 +137,14 @@ public class TemplateValidationErrorDefinition<TParameter> : ValidationErrorDefi
     /// <param name="parameter">The fixed rule parameter.</param>
     /// <param name="code">The default error code.</param>
     /// <param name="metadata">The default error metadata.</param>
-    /// <param name="target">The default absolute error target.</param>
+    /// <param name="target">The default error target.</param>
     /// <param name="category">The default error category.</param>
     public TemplateValidationErrorDefinition(
         IValidationErrorMessageTemplate<TParameter> template,
         TParameter parameter,
         string? code = null,
         MetadataObject? metadata = null,
-        string? target = null,
+        ValidationTarget? target = null,
         ErrorCategory category = ErrorCategory.Validation
     )
         : base(parameter, code, metadata, target, category)

--- a/src/Light.PortableResults.Validation/ValidationTarget.cs
+++ b/src/Light.PortableResults.Validation/ValidationTarget.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace Light.PortableResults.Validation;
+
+/// <summary>
+/// Describes how a validation target input must be interpreted and whether it is already normalized.
+/// </summary>
+public readonly record struct ValidationTarget
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ValidationTarget" />.
+    /// </summary>
+    /// <param name="input">The target input text.</param>
+    /// <param name="semantics">The semantics used to interpret <paramref name="input" />.</param>
+    /// <param name="isNormalized">
+    /// <see langword="true" /> when <paramref name="input" /> is already normalized for the specified
+    /// <paramref name="semantics" />; otherwise, <see langword="false" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="input" /> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="semantics" /> is not supported.</exception>
+    public ValidationTarget(string input, ValidationTargetSemantics semantics, bool isNormalized = false)
+    {
+        Input = input ?? throw new ArgumentNullException(nameof(input));
+        if (!semantics.IsDefined())
+        {
+            throw new ArgumentOutOfRangeException(nameof(semantics));
+        }
+
+        Semantics = semantics;
+        IsNormalized = isNormalized;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this instance is the default value.
+    /// </summary>
+    public bool IsDefault => Input is null;
+
+    /// <summary>
+    /// Gets the target input text.
+    /// </summary>
+    public string Input { get; }
+
+    /// <summary>
+    /// Gets the semantics used to interpret <see cref="Input" />.
+    /// </summary>
+    public ValidationTargetSemantics Semantics { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Input" /> is already normalized for <see cref="Semantics" />.
+    /// </summary>
+    public bool IsNormalized { get; }
+
+    /// <summary>
+    /// Creates a caller-expression target.
+    /// </summary>
+    public static ValidationTarget CallerExpression(string input, bool isNormalized = false) =>
+        new (input, ValidationTargetSemantics.CallerExpression, isNormalized);
+
+    /// <summary>
+    /// Creates a relative validation target.
+    /// </summary>
+    public static ValidationTarget Relative(string input, bool isNormalized = false) =>
+        new (input, ValidationTargetSemantics.Relative, isNormalized);
+
+    /// <summary>
+    /// Creates an absolute validation target.
+    /// </summary>
+    public static ValidationTarget Absolute(string input, bool isNormalized = false) =>
+        new (input, ValidationTargetSemantics.Absolute, isNormalized);
+}

--- a/src/Light.PortableResults.Validation/ValidationTargetSemantics.cs
+++ b/src/Light.PortableResults.Validation/ValidationTargetSemantics.cs
@@ -1,0 +1,38 @@
+namespace Light.PortableResults.Validation;
+
+/// <summary>
+/// Specifies how a validation target input string must be interpreted.
+/// </summary>
+public enum ValidationTargetSemantics
+{
+    /// <summary>
+    /// The input is a caller-expression-style target that still needs caller-expression normalization.
+    /// </summary>
+    CallerExpression,
+
+    /// <summary>
+    /// The input is a target path relative to the current validation scope.
+    /// </summary>
+    Relative,
+
+    /// <summary>
+    /// The input is an absolute target path for the entire validation run.
+    /// </summary>
+    Absolute
+}
+
+/// <summary>
+/// Provides helper methods for working with <see cref="ValidationTargetSemantics" /> values.
+/// </summary>
+public static class ValidationTargetSemanticsExtensions
+{
+    /// <summary>
+    /// Determines whether the specified <see cref="ValidationTargetSemantics" /> value is a defined enum member.
+    /// </summary>
+    /// <param name="semantics">The semantics value to validate.</param>
+    /// <returns><see langword="true" /> if <paramref name="semantics" /> is a defined value; otherwise, <see langword="false" />.</returns>
+    public static bool IsDefined(this ValidationTargetSemantics semantics) =>
+        semantics is ValidationTargetSemantics.CallerExpression or
+                     ValidationTargetSemantics.Relative or
+                     ValidationTargetSemantics.Absolute;
+}

--- a/src/Light.PortableResults.Validation/ValidationTargets.cs
+++ b/src/Light.PortableResults.Validation/ValidationTargets.cs
@@ -13,6 +13,24 @@ public static class ValidationTargets
     public static IValidationTargetNormalizer DefaultNormalizer { get; } = new DefaultValidationTargetNormalizer();
 
     /// <summary>
+    /// Creates a caller-expression validation target.
+    /// </summary>
+    public static ValidationTarget CallerExpression(string input, bool isNormalized = false) =>
+        ValidationTarget.CallerExpression(input, isNormalized);
+
+    /// <summary>
+    /// Creates a relative validation target.
+    /// </summary>
+    public static ValidationTarget Relative(string input, bool isNormalized = false) =>
+        ValidationTarget.Relative(input, isNormalized);
+
+    /// <summary>
+    /// Creates an absolute validation target.
+    /// </summary>
+    public static ValidationTarget Absolute(string input, bool isNormalized = false) =>
+        ValidationTarget.Absolute(input, isNormalized);
+
+    /// <summary>
     /// Composes a parent prefix and child target using the same flat-path rules as the validation infrastructure.
     /// </summary>
     /// <param name="prefix">The parent prefix. Use an empty string for the root object.</param>

--- a/src/Light.PortableResults.Validation/Validator.cs
+++ b/src/Light.PortableResults.Validation/Validator.cs
@@ -27,21 +27,36 @@ public abstract class Validator<T> : BaseValidator<T>
     /// Validates the specified value with a fresh validation context.
     /// </summary>
     /// <param name="value">The value to validate.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public Result<T> Validate(
         T? value,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
-    ) => Validate(value, ValidationContextFactory.CreateValidationContext(), target, displayName);
+    ) => Validate(
+        value,
+        ValidationContextFactory.CreateValidationContext(),
+        ValidationTarget.CallerExpression(target),
+        displayName
+    );
+
+    /// <summary>
+    /// Validates the specified value with a fresh validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public Result<T> Validate(T? value, ValidationTarget target, string? displayName = null) =>
+        Validate(value, ValidationContextFactory.CreateValidationContext(), target, displayName);
 
     /// <summary>
     /// Validates the specified value with the provided validation context.
     /// </summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="context">The validation context.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public Result<T> Validate(
@@ -49,14 +64,33 @@ public abstract class Validator<T> : BaseValidator<T>
         ValidationContext context,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
-    ) => FinalizeValidation(context, ValidateChildValue(value, context, target, displayName));
+    ) => FinalizeValidation(
+        context,
+        ValidateChildValue(value, context, ValidationTarget.CallerExpression(target), displayName)
+    );
+
+    /// <summary>
+    /// Validates the specified value with the provided validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public Result<T> Validate(
+        T? value,
+        ValidationContext context,
+        ValidationTarget target,
+        string? displayName = null
+    ) =>
+        FinalizeValidation(context, ValidateChildValue(value, context, target, displayName));
 
     /// <summary>
     /// Validates the value and materializes failures as a non-generic <see cref="Result" />.
     /// </summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
     public bool CheckForErrors(
@@ -64,7 +98,25 @@ public abstract class Validator<T> : BaseValidator<T>
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
-    ) => CheckForErrors(value, ValidationContextFactory.CreateValidationContext(), out failure, target, displayName);
+    ) =>
+        CheckForErrors(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out failure,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the value and materializes failures as a non-generic <see cref="Result" /> using an explicit target descriptor.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
+    public bool CheckForErrors(T? value, out Result failure, ValidationTarget target, string? displayName = null) =>
+        CheckForErrors(value, ValidationContextFactory.CreateValidationContext(), out failure, target, displayName);
 
     /// <summary>
     /// Validates the value with the specified context and materializes failures as a non-generic <see cref="Result" />.
@@ -72,7 +124,7 @@ public abstract class Validator<T> : BaseValidator<T>
     /// <param name="value">The value to validate.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
     public bool CheckForErrors(
@@ -80,6 +132,23 @@ public abstract class Validator<T> : BaseValidator<T>
         ValidationContext context,
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) => CheckForErrors(value, context, out failure, ValidationTarget.CallerExpression(target), displayName);
+
+    /// <summary>
+    /// Validates the value with the specified context and materializes failures as a non-generic <see cref="Result" />.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
+    public bool CheckForErrors(
+        T? value,
+        ValidationContext context,
+        out Result failure,
+        ValidationTarget target,
         string? displayName = null
     )
     {
@@ -100,7 +169,7 @@ public abstract class Validator<T> : BaseValidator<T>
     /// <param name="value">The value to validate.</param>
     /// <param name="validatedValue">The validated value on success.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
     public bool TryValidate(
@@ -109,12 +178,64 @@ public abstract class Validator<T> : BaseValidator<T>
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) =>
+        TryValidate(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out validatedValue,
+            out failure,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified value and returns the normalized value on success using an explicit target descriptor.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="validatedValue">The validated value on success.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
+    public bool TryValidate(
+        T? value,
+        [MaybeNullWhen(false)] out T validatedValue,
+        out Result failure,
+        ValidationTarget target,
+        string? displayName = null
+    ) =>
+        TryValidate(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out validatedValue,
+            out failure,
+            target,
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified value with the provided context and returns the normalized value on success.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="validatedValue">The validated value on success.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
+    public bool TryValidate(
+        T? value,
+        ValidationContext context,
+        [MaybeNullWhen(false)] out T validatedValue,
+        out Result failure,
+        [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
     ) => TryValidate(
         value,
-        ValidationContextFactory.CreateValidationContext(),
+        context,
         out validatedValue,
         out failure,
-        target,
+        ValidationTarget.CallerExpression(target),
         displayName
     );
 
@@ -125,7 +246,7 @@ public abstract class Validator<T> : BaseValidator<T>
     /// <param name="context">The validation context.</param>
     /// <param name="validatedValue">The validated value on success.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The explicit target descriptor.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
     public bool TryValidate(
@@ -133,7 +254,7 @@ public abstract class Validator<T> : BaseValidator<T>
         ValidationContext context,
         [MaybeNullWhen(false)] out T validatedValue,
         out Result failure,
-        [CallerArgumentExpression("value")] string target = "",
+        ValidationTarget target,
         string? displayName = null
     )
     {
@@ -156,9 +277,7 @@ public abstract class Validator<T> : BaseValidator<T>
     /// </summary>
     /// <param name="value">The value to be validated.</param>
     /// <param name="context">The validation context.</param>
-    /// <param name="target">
-    /// The raw caller expression for the value. Will be used to automatically create the target of an error.
-    /// </param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
     /// <returns>The validated and potentially normalized value.</returns>
     public ValidatedValue<T> ValidateChildValue(
@@ -166,10 +285,25 @@ public abstract class Validator<T> : BaseValidator<T>
         ValidationContext context,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) => ValidateChildValue(value, context, ValidationTarget.CallerExpression(target), displayName);
+
+    /// <summary>
+    /// Validates the specified value with the provided validation context and explicit target semantics.
+    /// </summary>
+    /// <param name="value">The value to be validated.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name which is used in formatted error messages.</param>
+    /// <returns>The validated and potentially normalized value.</returns>
+    public ValidatedValue<T> ValidateChildValue(
+        T? value,
+        ValidationContext context,
+        ValidationTarget target,
+        string? displayName = null
     )
     {
         ValidateCallArguments(context, target);
-        displayName ??= target;
+        displayName ??= target.Input;
         if (TryHandleAutomaticNull(value, context, target, displayName))
         {
             return ValidatedValue<T>.NoValue;
@@ -214,27 +348,60 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// Validates the specified source value and transforms it into a validated output.
     /// </summary>
     /// <param name="value">The source value.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public Result<TValidated> Validate(
         TSource? value,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
-    ) => Validate(value, ValidationContextFactory.CreateValidationContext(), target, displayName);
+    ) => Validate(
+        value,
+        ValidationContextFactory.CreateValidationContext(),
+        ValidationTarget.CallerExpression(target),
+        displayName
+    );
+
+    /// <summary>
+    /// Validates the specified source value and transforms it into a validated output using an explicit target descriptor.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public Result<TValidated> Validate(TSource? value, ValidationTarget target, string? displayName = null) =>
+        Validate(value, ValidationContextFactory.CreateValidationContext(), target, displayName);
 
     /// <summary>
     /// Validates the specified source value with the provided context and transforms it into a validated output.
     /// </summary>
     /// <param name="value">The source value.</param>
     /// <param name="context">The validation context.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns>The validation result.</returns>
     public Result<TValidated> Validate(
         TSource? value,
         ValidationContext context,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) => FinalizeValidation(
+        context,
+        ValidateChildValue(value, context, ValidationTarget.CallerExpression(target), displayName)
+    );
+
+    /// <summary>
+    /// Validates the specified source value with the provided context and transforms it into a validated output.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns>The validation result.</returns>
+    public Result<TValidated> Validate(
+        TSource? value,
+        ValidationContext context,
+        ValidationTarget target,
         string? displayName = null
     ) => FinalizeValidation(context, ValidateChildValue(value, context, target, displayName));
 
@@ -243,13 +410,35 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// </summary>
     /// <param name="value">The source value.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
     public bool CheckForErrors(
         TSource? value,
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) =>
+        CheckForErrors(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out failure,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the value and materializes failures as a non-generic <see cref="Result" /> using an explicit target descriptor.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
+    public bool CheckForErrors(
+        TSource? value,
+        out Result failure,
+        ValidationTarget target,
         string? displayName = null
     ) =>
         CheckForErrors(value, ValidationContextFactory.CreateValidationContext(), out failure, target, displayName);
@@ -260,7 +449,7 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// <param name="value">The source value.</param>
     /// <param name="context">The validation context.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
     public bool CheckForErrors(
@@ -268,6 +457,23 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
         ValidationContext context,
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
+    ) => CheckForErrors(value, context, out failure, ValidationTarget.CallerExpression(target), displayName);
+
+    /// <summary>
+    /// Validates the value with the specified context and materializes failures as a non-generic <see cref="Result" />.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> when validation failed; otherwise, <see langword="false" />.</returns>
+    public bool CheckForErrors(
+        TSource? value,
+        ValidationContext context,
+        out Result failure,
+        ValidationTarget target,
         string? displayName = null
     )
     {
@@ -288,7 +494,7 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// <param name="value">The source value.</param>
     /// <param name="validatedValue">The validated output on success.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
     public bool TryValidate(
@@ -297,12 +503,64 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
         out Result failure,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) =>
+        TryValidate(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out validatedValue,
+            out failure,
+            ValidationTarget.CallerExpression(target),
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified source value and returns the transformed validated output on success using an explicit target descriptor.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="validatedValue">The validated output on success.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The explicit target descriptor.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
+    public bool TryValidate(
+        TSource? value,
+        [MaybeNullWhen(false)] out TValidated validatedValue,
+        out Result failure,
+        ValidationTarget target,
+        string? displayName = null
+    ) =>
+        TryValidate(
+            value,
+            ValidationContextFactory.CreateValidationContext(),
+            out validatedValue,
+            out failure,
+            target,
+            displayName
+        );
+
+    /// <summary>
+    /// Validates the specified source value with the provided context and returns the transformed validated output on success.
+    /// </summary>
+    /// <param name="value">The source value.</param>
+    /// <param name="context">The validation context.</param>
+    /// <param name="validatedValue">The validated output on success.</param>
+    /// <param name="failure">The failure result when validation fails.</param>
+    /// <param name="target">The caller-expression target for the value.</param>
+    /// <param name="displayName">The optional display name.</param>
+    /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
+    public bool TryValidate(
+        TSource? value,
+        ValidationContext context,
+        [MaybeNullWhen(false)] out TValidated validatedValue,
+        out Result failure,
+        [CallerArgumentExpression("value")] string target = "",
+        string? displayName = null
     ) => TryValidate(
         value,
-        ValidationContextFactory.CreateValidationContext(),
+        context,
         out validatedValue,
         out failure,
-        target,
+        ValidationTarget.CallerExpression(target),
         displayName
     );
 
@@ -313,7 +571,7 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// <param name="context">The validation context.</param>
     /// <param name="validatedValue">The validated output on success.</param>
     /// <param name="failure">The failure result when validation fails.</param>
-    /// <param name="target">The raw caller expression for the value.</param>
+    /// <param name="target">The explicit target descriptor.</param>
     /// <param name="displayName">The optional display name.</param>
     /// <returns><see langword="true" /> on success; otherwise, <see langword="false" />.</returns>
     public bool TryValidate(
@@ -321,7 +579,7 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
         ValidationContext context,
         [MaybeNullWhen(false)] out TValidated validatedValue,
         out Result failure,
-        [CallerArgumentExpression("value")] string target = "",
+        ValidationTarget target,
         string? displayName = null
     )
     {
@@ -342,7 +600,7 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
     /// </summary>
     /// <param name="value">The child value that should be validated.</param>
     /// <param name="context">The ambient validation context shared with the parent validator.</param>
-    /// <param name="target">The caller expression associated with the value.</param>
+    /// <param name="target">The caller-expression target associated with the value.</param>
     /// <param name="displayName">An optional friendly name for the value; defaults to <paramref name="target" /> when omitted.</param>
     /// <returns>
     /// A <see cref="ValidatedValue{TValidated}" /> representing the successful child result or <see cref="ValidatedValue{TValidated}.NoValue" /> when
@@ -353,10 +611,28 @@ public abstract class Validator<TSource, TValidated> : BaseValidator<TSource>
         ValidationContext context,
         [CallerArgumentExpression("value")] string target = "",
         string? displayName = null
+    ) => ValidateChildValue(value, context, ValidationTarget.CallerExpression(target), displayName);
+
+    /// <summary>
+    /// Validates a child value using the existing validation context without emitting failures to the caller.
+    /// </summary>
+    /// <param name="value">The child value that should be validated.</param>
+    /// <param name="context">The ambient validation context shared with the parent validator.</param>
+    /// <param name="target">The explicit target descriptor associated with the value.</param>
+    /// <param name="displayName">An optional friendly name for the value; defaults to <paramref name="target" /> when omitted.</param>
+    /// <returns>
+    /// A <see cref="ValidatedValue{TValidated}" /> representing the successful child result or <see cref="ValidatedValue{TValidated}.NoValue" /> when
+    /// validation is bypassed.
+    /// </returns>
+    public ValidatedValue<TValidated> ValidateChildValue(
+        TSource? value,
+        ValidationContext context,
+        ValidationTarget target,
+        string? displayName = null
     )
     {
         ValidateCallArguments(context, target);
-        displayName ??= target;
+        displayName ??= target.Input;
         if (TryHandleAutomaticNull(value, context, target, displayName))
         {
             return ValidatedValue<TValidated>.NoValue;

--- a/tests/Light.PortableResults.Validation.Tests/CheckExtensionsTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/CheckExtensionsTests.cs
@@ -39,12 +39,16 @@ public sealed class CheckExtensionsTests
     }
 
     [Fact]
-    public void ValidateChild_ShouldTreatNormalizedTargetsAsAbsoluteWithinCurrentScope()
+    public void ValidateChild_ShouldRespectExplicitAbsoluteTargetsWithinCurrentScope()
     {
         var context = ValidationContextFactory.CreateValidationContext();
         var addressContext = context.ForMember("address", isNormalized: true);
         var check = addressContext
-           .Check(new AddressDto { ZipCode = " " }, target: "address", displayName: "Address")
+           .Check(
+                new AddressDto { ZipCode = " " },
+                ValidationTarget.Absolute("address", isNormalized: true),
+                displayName: "Address"
+            )
            .NormalizeTargetIfNecessary();
 
         var result = check.ValidateChild(new AddressValidator(ValidationContextFactory));
@@ -64,14 +68,14 @@ public sealed class CheckExtensionsTests
     }
 
     [Fact]
-    public void ValidateItems_ShouldTreatNormalizedCollectionTargetsAsAbsoluteWithinCurrentScope()
+    public void ValidateItems_ShouldRespectExplicitAbsoluteCollectionTargetsWithinCurrentScope()
     {
         var context = ValidationContextFactory.CreateValidationContext();
         var addressesContext = context.ForMember("addresses", isNormalized: true);
         var check = addressesContext
            .Check(
                 new List<AddressDto> { new () { ZipCode = " " } },
-                target: "addresses",
+                ValidationTarget.Absolute("addresses", isNormalized: true),
                 displayName: "Addresses"
             )
            .NormalizeTargetIfNecessary();

--- a/tests/Light.PortableResults.Validation.Tests/CheckExtensionsTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/CheckExtensionsTests.cs
@@ -16,13 +16,11 @@ public sealed class CheckExtensionsTests
     public void ValidateChild_ShouldNormalizeRawTargetsOnlyOnce()
     {
         var context = ValidationContextFactory.CreateValidationContext();
-        var check = context.Check(
-            new AddressDto { ZipCode = " " },
-            target: "request.Address",
-            displayName: "Address"
-        );
+        var addressValidator = new AddressValidator(ValidationContextFactory);
 
-        var result = check.ValidateChild(new AddressValidator(ValidationContextFactory));
+        var result = context
+           .Check(new AddressDto { ZipCode = " " }, target: "request.Address", displayName: "Address")
+           .ValidateChild(addressValidator);
 
         result.Should().Be(ValidatedValue<AddressDto>.NoValue);
         context.ToErrors().Should().Equal(

--- a/tests/Light.PortableResults.Validation.Tests/ValidationContextOptimizationTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/ValidationContextOptimizationTests.cs
@@ -40,7 +40,8 @@ public sealed class ValidationContextOptimizationTests
 
         context.AddError("firstName must not be empty", "NotEmpty", ValidationTarget.Relative("firstName", true));
         addressContext.AddError("zipCode must not be empty", "NotEmpty", ValidationTarget.Relative("zipCode", true));
-        addressesContext.ForIndex(0)
+        addressesContext
+           .ForIndex(0)
            .AddError("zipCode must not be empty", "NotEmpty", ValidationTarget.Relative("zipCode", true));
 
         context.ToErrors().Should().Equal(

--- a/tests/Light.PortableResults.Validation.Tests/ValidationContextOptimizationTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/ValidationContextOptimizationTests.cs
@@ -38,9 +38,10 @@ public sealed class ValidationContextOptimizationTests
         var addressContext = context.ForMember("address", isNormalized: true);
         var addressesContext = context.ForMember("addresses", isNormalized: true);
 
-        context.AddError("firstName must not be empty", "NotEmpty", "firstName");
-        addressContext.AddError("zipCode must not be empty", "NotEmpty", "zipCode");
-        addressesContext.ForIndex(0).AddError("zipCode must not be empty", "NotEmpty", "zipCode");
+        context.AddError("firstName must not be empty", "NotEmpty", ValidationTarget.Relative("firstName", true));
+        addressContext.AddError("zipCode must not be empty", "NotEmpty", ValidationTarget.Relative("zipCode", true));
+        addressesContext.ForIndex(0)
+           .AddError("zipCode must not be empty", "NotEmpty", ValidationTarget.Relative("zipCode", true));
 
         context.ToErrors().Should().Equal(
             new Errors(
@@ -58,7 +59,7 @@ public sealed class ValidationContextOptimizationTests
     public void ToErrors_ShouldMaterializeSingleErrorInline()
     {
         var context = ValidationContextFactory.CreateValidationContext();
-        context.AddError("firstName must not be empty", "NotEmpty", "firstName");
+        context.AddError("firstName must not be empty", "NotEmpty", ValidationTarget.Relative("firstName", true));
 
         var errors = context.ToErrors();
         var manyErrors = GetManyErrorsMemory(errors);
@@ -73,8 +74,8 @@ public sealed class ValidationContextOptimizationTests
     public void ToErrors_ShouldWrapOwnedArrayWithoutCopyForTwoErrors()
     {
         var context = ValidationContextFactory.CreateValidationContext();
-        context.AddError("firstName must not be empty", "NotEmpty", "firstName");
-        context.AddError("age must be at least 18", "Adult", "age");
+        context.AddError("firstName must not be empty", "NotEmpty", ValidationTarget.Relative("firstName", true));
+        context.AddError("age must be at least 18", "Adult", ValidationTarget.Relative("age", true));
 
         var errors = context.ToErrors();
         var segment = GetBackingSegment(errors);

--- a/tests/Light.PortableResults.Validation.Tests/ValidationContextTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/ValidationContextTests.cs
@@ -56,12 +56,40 @@ public sealed class ValidationContextTests
     }
 
     [Fact]
+    public void Check_WithExplicitStringTarget_ShouldStillUseCallerExpressionSemantics()
+    {
+        var context = new DefaultValidationContextFactory().CreateValidationContext();
+        var childContext = context.ForMember("customer", isNormalized: true);
+
+        var check = childContext.Check("Alice", target: "request.FirstName").NormalizeTargetIfNecessary();
+
+        check.Target.Should().Be("customer.firstName");
+    }
+
+    [Fact]
+    public void Check_ShouldSupportExplicitRelativeAndAbsoluteTargets()
+    {
+        var context = new DefaultValidationContextFactory().CreateValidationContext();
+        var childContext = context.ForMember("customer", isNormalized: true);
+
+        var relativeCheck = childContext
+           .Check("Alice", ValidationTarget.Relative("firstName", isNormalized: true))
+           .NormalizeTargetIfNecessary();
+        var absoluteCheck = childContext
+           .Check("Alice", ValidationTarget.Absolute("account.ownerName", isNormalized: true))
+           .NormalizeTargetIfNecessary();
+
+        relativeCheck.Target.Should().Be("customer.firstName");
+        absoluteCheck.Target.Should().Be("account.ownerName");
+    }
+
+    [Fact]
     public void AddError_ShouldMaterializeFlatErrorsAndFailureResult()
     {
         var context = new DefaultValidationContextFactory().CreateValidationContext();
 
-        context.AddError("first name is required", "NotEmpty", "firstName");
-        context.AddError("age must be at least 18", "Adult", "age");
+        context.AddError("first name is required", "NotEmpty", ValidationTarget.Relative("firstName", true));
+        context.AddError("age must be at least 18", "Adult", ValidationTarget.Relative("age", true));
 
         context.TryGetErrors(out var errors).Should().BeTrue();
         errors.Should().Equal(
@@ -126,7 +154,11 @@ public sealed class ValidationContextTests
         var context = new DefaultValidationContextFactory().CreateValidationContext();
         var childContext = context.ForMember("address", isNormalized: true);
 
-        childContext.AddError("zip code is invalid", "InvalidZipCode", "zipCode");
+        childContext.AddError(
+            "zip code is invalid",
+            "InvalidZipCode",
+            ValidationTarget.Relative("zipCode", true)
+        );
 
         context.ToErrors().Should().Equal(
             new Errors(

--- a/tests/Light.PortableResults.Validation.Tests/ValidationErrorDefinitionTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/ValidationErrorDefinitionTests.cs
@@ -85,7 +85,7 @@ public sealed class ValidationErrorDefinitionTests
             new ConstantValidationErrorMessageTemplate("Zip code is invalid"),
             code: "InvalidZipCode",
             metadata: MetadataObject.Create(("hint", (MetadataValue) "definition")),
-            target: "orders[2].postalCode",
+            target: ValidationTarget.Absolute("orders[2].postalCode", isNormalized: true),
             category: ErrorCategory.Validation
         );
         var overrideMetadata = MetadataObject.Create(("hint", (MetadataValue) "override"));
@@ -95,7 +95,7 @@ public sealed class ValidationErrorDefinitionTests
             definition,
             code: "Overridden",
             metadata: overrideMetadata,
-            target: "postalCode",
+            target: ValidationTarget.Relative("postalCode", isNormalized: true),
             category: ErrorCategory.Conflict
         );
 
@@ -122,7 +122,7 @@ public sealed class ValidationErrorDefinitionTests
            .Check("X", target: "address.zipCode", displayName: "Postal code")
            .NormalizeTargetIfNecessary();
 
-        check.AddError(definition, target: "address.postalCode");
+        check.AddError(definition, target: ValidationTarget.Relative("address.postalCode", isNormalized: true));
 
         context.ToErrors().Should().Equal(
             new Errors(
@@ -143,7 +143,7 @@ public sealed class ValidationErrorDefinitionTests
         var childContext = context.ForMember("address", isNormalized: true);
         var definition = new TemplateValidationErrorDefinition(
             new ConstantValidationErrorMessageTemplate("Zip code is invalid"),
-            target: "address.zipCode"
+            target: ValidationTarget.Absolute("address.zipCode", isNormalized: true)
         );
         var check = childContext.Check("X", target: "zipCode", displayName: "Zip code").NormalizeTargetIfNecessary();
 

--- a/tests/Light.PortableResults.Validation.Tests/ValidationTargetNormalizationTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/ValidationTargetNormalizationTests.cs
@@ -5,33 +5,87 @@ namespace Light.PortableResults.Validation.Tests;
 
 public sealed class ValidationTargetNormalizationTests
 {
-    public static TheoryData<string, ValidationTargetCasing, string> RepresentativeTargets =>
+    public static TheoryData<string, ValidationTargetSemantics, ValidationTargetCasing, string> RepresentativeTargets =>
         new ()
         {
-            { "ZipCode", ValidationTargetCasing.CamelCase, "zipCode" },
-            { "dto", ValidationTargetCasing.CamelCase, "dto" },
-            { "dto.Address.ZipCode", ValidationTargetCasing.CamelCase, "address.zipCode" },
-            { "dto.Addresses[0].ZipCode", ValidationTargetCasing.CamelCase, "addresses[0].zipCode" },
-            { "  dto. Address . ZipCode  ", ValidationTargetCasing.CamelCase, "address.zipCode" },
-            { "dto.@Address.@ZipCode", ValidationTargetCasing.CamelCase, "address.zipCode" },
-            { "dto.address.zipCode", ValidationTargetCasing.PascalCase, "Address.ZipCode" },
-            { "dto.Address.ZipCode", ValidationTargetCasing.Preserve, "Address.ZipCode" },
-            { "dto.Address[0", ValidationTargetCasing.CamelCase, "address[0" },
-            { "dto.", ValidationTargetCasing.CamelCase, string.Empty },
-            { " \t ", ValidationTargetCasing.CamelCase, string.Empty }
+            { "ZipCode", ValidationTargetSemantics.CallerExpression, ValidationTargetCasing.CamelCase, "zipCode" },
+            { "dto", ValidationTargetSemantics.CallerExpression, ValidationTargetCasing.CamelCase, "dto" },
+            {
+                "dto.Address.ZipCode",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.CamelCase,
+                "address.zipCode"
+            },
+            {
+                "dto.Addresses[0].ZipCode",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.CamelCase,
+                "addresses[0].zipCode"
+            },
+            {
+                "  dto. Address . ZipCode  ",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.CamelCase,
+                "address.zipCode"
+            },
+            {
+                "dto.@Address.@ZipCode",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.CamelCase,
+                "address.zipCode"
+            },
+            {
+                "dto.address.zipCode",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.PascalCase,
+                "Address.ZipCode"
+            },
+            {
+                "dto.Address.ZipCode",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.Preserve,
+                "Address.ZipCode"
+            },
+            {
+                "dto.Address[0",
+                ValidationTargetSemantics.CallerExpression,
+                ValidationTargetCasing.CamelCase,
+                "address[0"
+            },
+            { "dto.", ValidationTargetSemantics.CallerExpression, ValidationTargetCasing.CamelCase, string.Empty },
+            { " \t ", ValidationTargetSemantics.CallerExpression, ValidationTargetCasing.CamelCase, string.Empty },
+            {
+                "Address.ZipCode",
+                ValidationTargetSemantics.Relative,
+                ValidationTargetCasing.CamelCase,
+                "address.zipCode"
+            },
+            {
+                "Addresses[0].ZipCode",
+                ValidationTargetSemantics.Absolute,
+                ValidationTargetCasing.CamelCase,
+                "addresses[0].zipCode"
+            },
+            {
+                "  Address . ZipCode  ",
+                ValidationTargetSemantics.Relative,
+                ValidationTargetCasing.CamelCase,
+                "address.zipCode"
+            }
         };
 
     [Theory]
     [MemberData(nameof(RepresentativeTargets))]
     public void DefaultNormalizer_ShouldNormalizeRepresentativeTargets(
         string rawPath,
+        ValidationTargetSemantics semantics,
         ValidationTargetCasing casing,
         string expectedTarget
     )
     {
         var normalizer = new DefaultValidationTargetNormalizer(casing);
 
-        var normalized = normalizer.Normalize(rawPath);
+        var normalized = normalizer.Normalize(rawPath, semantics);
 
         normalized.Should().Be(expectedTarget);
     }
@@ -41,8 +95,8 @@ public sealed class ValidationTargetNormalizationTests
     {
         var normalizer = new DefaultValidationTargetNormalizer();
 
-        var first = normalizer.Normalize("dto.Address.ZipCode");
-        var second = normalizer.Normalize("dto.Address.ZipCode");
+        var first = normalizer.Normalize("dto.Address.ZipCode", ValidationTargetSemantics.CallerExpression);
+        var second = normalizer.Normalize("dto.Address.ZipCode", ValidationTargetSemantics.CallerExpression);
 
         ReferenceEquals(first, second).Should().BeTrue();
     }


### PR DESCRIPTION
Closes #30

This pull request introduces an explicit and type-safe model for validation targets throughout the validation library, addressing ambiguity and complexity in how target paths are handled. The new approach replaces overloaded string-based target parameters with a dedicated `ValidationTarget` type, clarifies API usage for both common and advanced scenarios, and ensures consistent semantics across synchronous and asynchronous validation flows. Documentation and benchmarks are updated to reflect these changes.

**Validation Target Redesign and API Changes**

* Introduced a new `ValidationTarget` type (with supporting enum) to explicitly distinguish between caller-expression, relative, and absolute validation targets, replacing ambiguous string-based target parameters. This change is thoroughly documented in the new design plan `ai-plans/0030-validation-target-redesign.md`.
* Updated all relevant validation APIs (including `AsyncValidator` methods) to accept and propagate `ValidationTarget` descriptors, with overloads for both common (caller-expression) and advanced (relative/absolute) usage. This includes new overloads for `ValidateAsync` and `ValidateChildValueAsync` that accept `ValidationTarget`, and internal logic to handle target resolution and display names accordingly. [[1]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6L31-R60) [[2]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6L54-R76) [[3]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6R85-R112) [[4]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6L79-R162) [[5]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6L144-R242) [[6]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6L167-R258) [[7]](diffhunk://#diff-e1fd3e7d9fdcb49cb18ac265275f498485d70af01f0317a2c39ba82ab6ab7af6R267-R294)

**Documentation and Example Updates**

* Expanded the `README.md` with clear guidance and code examples for advanced manual target control using `ValidationTarget.Relative` and `ValidationTarget.Absolute`, and explained the continued use of string-based targets for common scenarios.

**Benchmark and Test Infrastructure Updates**

* Updated benchmark code in `ValidationContextBenchmarks.cs` to use the new `ValidationTarget.Relative` API for error accumulation and context creation, ensuring benchmarks reflect the new explicit target handling. [[1]](diffhunk://#diff-43ffc4e7df7cc8aec0abf5e73e5952fa93f4181275dd8e2156c07e2229ed9da0L40-R44) [[2]](diffhunk://#diff-43ffc4e7df7cc8aec0abf5e73e5952fa93f4181275dd8e2156c07e2229ed9da0L81-R89)

**Solution and Planning Updates**

* Added the new design plan file `ai-plans/0030-validation-target-redesign.md` to the solution for traceability and future reference.