### PR TITLE
0.4.0 Preparations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Authors>Kenny Pflug</Authors>
     <Company>Kenny Pflug</Company>
     <Copyright>Copyright (c) 2026 Kenny Pflug</Copyright>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -658,17 +658,19 @@ public sealed class PurchaseOrderValidator : Validator<PurchaseOrderDto>
         // automatically — no explicit IsNotNull() call needed here.
         context.Check(dto.ShippingAddress).ValidateChild(_addressValidator);
 
-        // All ValidateItems overloads require a non-null collection. Guard with IsNotNull()
-        // when the collection itself can be null (which short-circuits ValidateItems on failure).
+        // ValidateItems automatically handles a null collection by emitting the standard
+        // NotNull error via the active AutomaticNullErrorProvider — no explicit IsNotNull()
+        // is needed under default configuration. Guard explicitly only when the provider is
+        // configured to skip automatic null errors (e.g. NoOpAutomaticNullErrorProvider).
         // The default string normalization already trims whitespace for individual string items,
         // so no IsNotNullOrWhiteSpace() is needed inside the lambda.
-        context.Check(dto.Tags).IsNotNull().ValidateItems(
+        context.Check(dto.Tags).ValidateItems(
             static (Check<string> tag) => tag.HasLengthIn(2, 30)
         );
 
         // ValidateItems with a Validator<TItem> delegates null-item handling to the item
         // validator's automatic null check, just like ValidateChild does for single objects.
-        context.Check(dto.Items).IsNotNull().ValidateItems(_itemValidator);
+        context.Check(dto.Items).ValidateItems(_itemValidator);
 
         return checkpoint.ToValidatedValue(dto);
     }
@@ -726,7 +728,31 @@ services
     .AddSingleton<PurchaseOrderValidator>();
 ```
 
-#### Validation Benchmarks
+### Automatic Null Checking
+
+The validation framework handles `null` values automatically so you rarely need an explicit `IsNotNull()` guard. The active `AutomaticNullErrorProvider` (configurable via `ValidationContextOptions`) decides what error to produce; under the default configuration it emits a `NotNull` validation error.
+
+- **Validators (`Validator<T>`, `Validator<TSource, TValidated>`, `AsyncValidator<T>`, `AsyncValidator<TSource, TValidated>`)** — when the source value passed to `Validate` / `ValidateAsync` is `null`, the validator adds the automatic null error and returns a failed `Result` without calling `PerformValidation(Async)`. The `isAutomaticNullCheckingEnabled` constructor parameter (default `true`) controls this per validator class.
+
+- **Child validation (`ValidateChild`, `ValidateChildAsync`)** — when a nested collection value is `null`, the child validator's own automatic null check fires, adds the error for the child target, and returns `ValidatedValue<T>.NoValue`. The parent continues collecting other errors in the same pass. `Check<T>` instances that are short-circuited are ignored (no automatic null error will be added to the context, `PerformValidation(Async)` will not be called).
+
+- **Collection item validation (`ValidateItems`, `ValidateItemsAsync`)** — when a `null` collection is passed on a non-short-circuited check, the same automatic null-error pipeline runs for the collection target and the method returns `ValidatedValue<...>.NoValue` without invoking any item validators or delegates. Regarding the items in the collection: item validators as well as delegates have automatic null checking of items, too.
+
+Guard explicitly with `IsNotNull()` when `NoOpAutomaticNullErrorProvider` was set on `ValidationContextOptions.AutomaticNullErrorProvider` (which means that automatic null errors are disabled).
+
+```csharp
+// Default configuration — automatic null handling, no explicit guard needed
+context.Check(dto.ShippingAddress).ValidateChild(_addressValidator);
+context.Check(dto.Tags).ValidateItems(static (Check<string> tag) => tag.HasLengthIn(2, 30));
+
+// Explicit guard — required when the active provider does not emit automatic null errors,
+// or when you want to short-circuit further checks on null
+context.Check(dto.Tags).IsNotNull().ValidateItems(static (Check<string> tag) => tag.HasLengthIn(2, 30));
+```
+
+Short-circuited checks are always a no-op: validation methods return `ValidatedValue<...>.NoValue` immediately without adding any error or invoking validators or delegates.
+
+### Validation Benchmarks
 
 Below are benchmark results comparing Light.PortableResults to FluentValidation using flat and composite DTOs (see the `benchmarks/Benchmarks` project for details). The `PurchaseOrderDto` example above corresponds to the Complex DTO scenario.
 
@@ -740,7 +766,7 @@ Apple M3 Max, 1 CPU, 16 logical and 16 physical cores
   DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
 ```
 
-##### Flat DTO Becnhmark Setup
+#### Flat DTO Becnhmark Setup
 
 ```csharp
 public sealed record MovieRatingDto
@@ -783,7 +809,7 @@ public sealed class LightPortableResultsMovieRatingDtoValidator : Validator<Movi
 
 The details can be found [here](https://github.com/feO2x/Light.PortableResults/blob/main/benchmarks/Benchmarks/FlatDtoValidationBenchmarks.cs).
 
-##### Valid Flat DTO Benchmarks
+#### Valid Flat DTO Benchmarks
 
 No errors on all three properties.
 
@@ -793,7 +819,7 @@ No errors on all three properties.
 | FluentValidationSingleton         |   105.84 ns | 0.246 ns | 0.205 ns |  0.08 | 0.0755 | 0.0001 |     632 B |        0.09 |
 | LightPortableResults              |    50.49 ns | 0.091 ns | 0.076 ns |  0.04 | 0.0124 |      - |     104 B |        0.01 |
 
-##### Invalid Flat DTO Benchmarks
+#### Invalid Flat DTO Benchmarks
 
 All three properties are invalid.
 
@@ -803,7 +829,7 @@ All three properties are invalid.
 | FluentValidationSingleton         | 1,793.6 ns |  3.93 ns | 3.48 ns |  0.57 | 0.9937 | 0.0095 |    8320 B |        0.57 |
 | LightPortableResults              |   289.6 ns |  0.57 ns | 0.51 ns |  0.09 | 0.0820 |      - |     688 B |        0.05 |
 
-##### Complex DTO Benchmark Setup
+#### Complex DTO Benchmark Setup
 
 This is the DTO with one nested object, one nested collection with primitive items (strings), and one nested collection with complex items.
 
@@ -835,7 +861,7 @@ public sealed record OrderItemDto
 
 The details can be found [here](https://github.com/feO2x/Light.PortableResults/blob/main/benchmarks/Benchmarks/ComplexDtoValidationBenchmarks.cs).
 
-##### Valid Complex DTO Benchmarks
+#### Valid Complex DTO Benchmarks
 
 No errors in the DTO object graph.
 
@@ -845,7 +871,7 @@ No errors in the DTO object graph.
 | FluentValidationSingleton         | 1,685.9 ns |  5.01 ns |  4.69 ns |  0.20 | 0.7057 | 0.0019 |   5.77 KB |        0.17 |
 | LightPortableResults              |   742.2 ns |  7.40 ns |  6.93 ns |  0.09 | 0.1554 |      - |   1.27 KB |        0.04 |
 
-##### Invalid Complex DTO Benchmarks
+#### Invalid Complex DTO Benchmarks
 
 Nine errors overall in the object graph.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *A high-performant, enterprise-grade .NET library implementing the Result Pattern where each result is serializable and deserializable. Comes with integrations for ASP.NET Core Minimal APIs and MVC, `HttpResponseMessage`, and CloudEvents JSON format, as well as a validation framework.*
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](https://github.com/feO2x/Light.PortableResults/blob/main/LICENSE)
-[![NuGet](https://img.shields.io/badge/NuGet-0.3.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages?q=Light.PortableResults)
+[![NuGet](https://img.shields.io/badge/NuGet-0.4.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages?q=Light.PortableResults)
 [![Documentation](https://img.shields.io/badge/Docs-Changelog-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.PortableResults/releases)
 
 ## ✨ Key Features

--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ Apple M3 Max, 1 CPU, 16 logical and 16 physical cores
   DefaultJob : .NET 10.0.5 (10.0.5, 10.0.526.15411), Arm64 RyuJIT armv8.0-a
 ```
 
-#### Flat DTO Becnhmark Setup
+#### Flat DTO Benchmark Setup
 
 ```csharp
 public sealed record MovieRatingDto

--- a/benchmarks/Benchmarks/CloudEventsReadingBenchmarks.cs
+++ b/benchmarks/Benchmarks/CloudEventsReadingBenchmarks.cs
@@ -24,7 +24,7 @@ public class CloudEventsReadingBenchmarks
     {
         _options = new PortableResultsCloudEventsReadOptions
         {
-            SerializerOptions = Module.CreateDefaultSerializerOptions()
+            SerializerOptions = PortableResultsCloudEventsReadingModule.CreateDefaultSerializerOptions()
         };
 
         // Small payload (~100 bytes data)

--- a/benchmarks/Benchmarks/CloudEventsWritingBenchmarks.cs
+++ b/benchmarks/Benchmarks/CloudEventsWritingBenchmarks.cs
@@ -28,7 +28,7 @@ public class CloudEventsWritingBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsCloudEventsWritingModule.CreateDefaultSerializerOptions();
         serializerOptions.TypeInfoResolverChain.Add(CloudEventsWritingBenchmarksJsonContext.Default);
 
         _options = new PortableResultsCloudEventsWriteOptions

--- a/benchmarks/Benchmarks/HttpReadDeserializationBenchmarks.cs
+++ b/benchmarks/Benchmarks/HttpReadDeserializationBenchmarks.cs
@@ -22,7 +22,7 @@ public class HttpReadDeserializationBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _optimizedOptions = Module.CreateDefaultSerializerOptions();
+        _optimizedOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
 
         _legacyOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
         _legacyOptions.AddDefaultPortableResultsHttpReadJsonConverters();

--- a/src/Light.PortableResults.AspNetCore.MinimalApis/Light.PortableResults.AspNetCore.MinimalApis.csproj
+++ b/src/Light.PortableResults.AspNetCore.MinimalApis/Light.PortableResults.AspNetCore.MinimalApis.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Integration package for turning result instances into Minimal API's IResult instances. Compatible with Native AOT. Compatible with RFC 9457 (and RFC 7807) Problem Details responses.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.MinimalApis 0.3.0
+      Light.PortableResults.AspNetCore.MinimalApis 0.4.0
       ---------------------------------
 
       - LightResult and LightResult&lt;T> and corresponding extension methods to turn result instances into HTTP success responses or RFC 9457 (and RFC 7807) compatible Problem Details responses.

--- a/src/Light.PortableResults.AspNetCore.MinimalApis/PortableResultsMinimalApisModule.cs
+++ b/src/Light.PortableResults.AspNetCore.MinimalApis/PortableResultsMinimalApisModule.cs
@@ -7,7 +7,7 @@ namespace Light.PortableResults.AspNetCore.MinimalApis;
 /// <summary>
 /// Service registration helpers for Light.PortableResults Minimal APIs.
 /// </summary>
-public static class Module
+public static class PortableResultsMinimalApisModule
 {
     /// <summary>
     /// Registers all services required for Light.PortableResults Minimal APIs.

--- a/src/Light.PortableResults.AspNetCore.Mvc/Light.PortableResults.AspNetCore.Mvc.csproj
+++ b/src/Light.PortableResults.AspNetCore.Mvc/Light.PortableResults.AspNetCore.Mvc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Integration package for turning result instances into MVC's IActionResult instances. Compatible with RFC 9457 (and RFC 7807) Problem Details responses.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.MVC 0.3.0
+      Light.PortableResults.AspNetCore.MVC 0.4.0
       ---------------------------------
 
       - LightActionResult and LightActionResult&lt;T> and corresponding extension methods to turn result instances into HTTP success responses or RFC 9457 (and RFC 7807) compatible Problem Details responses.

--- a/src/Light.PortableResults.AspNetCore.Mvc/PortableResultsMvcModule.cs
+++ b/src/Light.PortableResults.AspNetCore.Mvc/PortableResultsMvcModule.cs
@@ -7,7 +7,7 @@ namespace Light.PortableResults.AspNetCore.Mvc;
 /// <summary>
 /// Service registration helpers for Light.PortableResults MVC.
 /// </summary>
-public static class Module
+public static class PortableResultsMvcModule
 {
     /// <summary>
     /// Registers all services required for Light.PortableResults MVC.

--- a/src/Light.PortableResults.AspNetCore.Shared/Light.PortableResults.AspNetCore.Shared.csproj
+++ b/src/Light.PortableResults.AspNetCore.Shared/Light.PortableResults.AspNetCore.Shared.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>The Light.PortableResults.AspNetCore.Shared package contains shared functionality for writing ASP.NET Core HTTP responses. Compatible with Native AOT. Check out the integration packages Light.PortableResults.AspNetCore.MinimalApis or Light.PortableResults.AspNetCore.Mvc.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.Shared 0.3.0
+      Light.PortableResults.AspNetCore.Shared 0.4.0
       ---------------------------------
 
       - Result enrichment with ASP.NET Core's HttpContext.

--- a/src/Light.PortableResults.Validation/CheckExtensions.cs
+++ b/src/Light.PortableResults.Validation/CheckExtensions.cs
@@ -187,10 +187,9 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
@@ -198,13 +197,13 @@ public static class CheckExtensions
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 collection[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -231,7 +230,7 @@ public static class CheckExtensions
             return ValidatedValue<ImmutableArray<TItem>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var collection = check.Value;
         for (var i = 0; i < collection.Length; i++)
         {
@@ -243,7 +242,7 @@ public static class CheckExtensions
             );
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -288,13 +287,13 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
             validateItem(CreateItemCheck(check, collection[i], i));
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -339,18 +338,17 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue = validateItem(CreateItemCheck(check, collection[i], i));
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 collection[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -394,11 +392,10 @@ public static class CheckExtensions
             return ValidatedValue<TValidated[]>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var validatedItems = new TValidated[collection.Length];
         for (var i = 0; i < collection.Length; i++)
         {
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
@@ -406,13 +403,13 @@ public static class CheckExtensions
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems);
+        return collectionCheckpoint.ToValidatedValue(validatedItems);
     }
 
     /// <summary>
@@ -455,11 +452,10 @@ public static class CheckExtensions
             return ValidatedValue<List<TValidated>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var validatedItems = new List<TValidated>(collection.Count);
         for (var i = 0; i < collection.Count; i++)
         {
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
@@ -467,13 +463,13 @@ public static class CheckExtensions
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems.Add(validatedValue.Value);
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems);
+        return collectionCheckpoint.ToValidatedValue(validatedItems);
     }
 
     /// <summary>
@@ -500,12 +496,11 @@ public static class CheckExtensions
             return ValidatedValue<ImmutableArray<TValidated>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var collection = check.Value;
         var validatedItems = ImmutableArray.CreateBuilder<TValidated>(collection.Length);
         for (var i = 0; i < collection.Length; i++)
         {
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue = itemValidator.ValidateChildValue(
                 collection[i],
                 check.CreateChildContextForIndex(i),
@@ -513,13 +508,13 @@ public static class CheckExtensions
                 displayName: CreateIndexedDisplayName(check, i)
             );
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems.Add(validatedValue.Value);
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems.DrainToImmutable());
+        return collectionCheckpoint.ToValidatedValue(validatedItems.DrainToImmutable());
     }
 
     /// <summary>
@@ -566,13 +561,13 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var itemCheckpoint = check.Context.CreateCheckpoint();
-            var validatedValue = await itemValidator.ValidateChildValueAsync(
+            var validatedValue = await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -581,13 +576,13 @@ public static class CheckExtensions
                 )
                .ConfigureAwait(false);
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 collection[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -631,12 +626,13 @@ public static class CheckExtensions
             return ValidatedValue<IReadOnlyList<TItem>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            await itemValidator.ValidateChildValueAsync(
+            await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -646,7 +642,7 @@ public static class CheckExtensions
                .ConfigureAwait(false);
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -674,12 +670,13 @@ public static class CheckExtensions
             return ValidatedValue<ImmutableArray<TItem>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var collection = check.Value;
         for (var i = 0; i < collection.Length; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await itemValidator.ValidateChildValueAsync(
+            await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -689,7 +686,7 @@ public static class CheckExtensions
                .ConfigureAwait(false);
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -735,14 +732,14 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await validateItem(CreateItemCheck(check, collection[i], i), cancellationToken).ConfigureAwait(false);
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -789,21 +786,20 @@ public static class CheckExtensions
             return ValidatedValue<TCollection>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var itemCheckpoint = check.Context.CreateCheckpoint();
             var validatedValue =
                 await validateItem(CreateItemCheck(check, collection[i], i), cancellationToken).ConfigureAwait(false);
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 collection[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(collection);
+        return collectionCheckpoint.ToValidatedValue(collection);
     }
 
     /// <summary>
@@ -849,14 +845,14 @@ public static class CheckExtensions
             return ValidatedValue<TValidated[]>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var validatedItems = new TValidated[collection.Length];
         for (var i = 0; i < collection.Length; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var itemCheckpoint = check.Context.CreateCheckpoint();
-            var validatedValue = await itemValidator.ValidateChildValueAsync(
+            var validatedValue = await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -865,13 +861,13 @@ public static class CheckExtensions
                 )
                .ConfigureAwait(false);
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems[i] = validatedValue.Value;
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems);
+        return collectionCheckpoint.ToValidatedValue(validatedItems);
     }
 
     /// <summary>
@@ -916,14 +912,14 @@ public static class CheckExtensions
             return ValidatedValue<List<TValidated>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var validatedItems = new List<TValidated>(collection.Count);
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var itemCheckpoint = check.Context.CreateCheckpoint();
-            var validatedValue = await itemValidator.ValidateChildValueAsync(
+            var validatedValue = await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -932,13 +928,13 @@ public static class CheckExtensions
                 )
                .ConfigureAwait(false);
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems.Add(validatedValue.Value);
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems);
+        return collectionCheckpoint.ToValidatedValue(validatedItems);
     }
 
     /// <summary>
@@ -968,15 +964,15 @@ public static class CheckExtensions
             return ValidatedValue<ImmutableArray<TValidated>>.NoValue;
         }
 
-        var checkpoint = check.Context.CreateCheckpoint();
+        var collectionCheckpoint = check.Context.CreateCheckpoint();
         var collection = check.Value;
         var validatedItems = ImmutableArray.CreateBuilder<TValidated>(collection.Length);
         for (var i = 0; i < collection.Length; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var itemCheckpoint = check.Context.CreateCheckpoint();
-            var validatedValue = await itemValidator.ValidateChildValueAsync(
+            var validatedValue = await itemValidator
+               .ValidateChildValueAsync(
                     collection[i],
                     check.CreateChildContextForIndex(i),
                     cancellationToken,
@@ -985,13 +981,13 @@ public static class CheckExtensions
                 )
                .ConfigureAwait(false);
 
-            if (!itemCheckpoint.HasNewErrors)
+            if (validatedValue.HasValue)
             {
                 validatedItems.Add(validatedValue.Value);
             }
         }
 
-        return checkpoint.ToValidatedValue(validatedItems.DrainToImmutable());
+        return collectionCheckpoint.ToValidatedValue(validatedItems.DrainToImmutable());
     }
 
     private static bool TryGetCollectionForItemValidation<TCollection>(

--- a/src/Light.PortableResults.Validation/CheckExtensions.cs
+++ b/src/Light.PortableResults.Validation/CheckExtensions.cs
@@ -290,6 +290,11 @@ public static class CheckExtensions
         var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
+            if (TryHandleItemAutomaticNull(check, collection[i], i))
+            {
+                continue;
+            }
+
             validateItem(CreateItemCheck(check, collection[i], i));
         }
 
@@ -341,6 +346,11 @@ public static class CheckExtensions
         var collectionCheckpoint = check.Context.CreateCheckpoint();
         for (var i = 0; i < collection.Count; i++)
         {
+            if (TryHandleItemAutomaticNull(check, collection[i], i))
+            {
+                continue;
+            }
+
             var validatedValue = validateItem(CreateItemCheck(check, collection[i], i));
             if (validatedValue.HasValue)
             {
@@ -736,6 +746,12 @@ public static class CheckExtensions
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (TryHandleItemAutomaticNull(check, collection[i], i))
+            {
+                continue;
+            }
+
             await validateItem(CreateItemCheck(check, collection[i], i), cancellationToken).ConfigureAwait(false);
         }
 
@@ -790,6 +806,11 @@ public static class CheckExtensions
         for (var i = 0; i < collection.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (TryHandleItemAutomaticNull(check, collection[i], i))
+            {
+                continue;
+            }
 
             var validatedValue =
                 await validateItem(CreateItemCheck(check, collection[i], i), cancellationToken).ConfigureAwait(false);
@@ -1017,6 +1038,34 @@ public static class CheckExtensions
         throw new InvalidOperationException(
             "ValidateItems and ValidateItemsAsync require a non-null collection when the active automatic-null provider does not create an error. Guard nullable collections explicitly, for example with IsNotNull(), before validating items."
         );
+    }
+
+    private static bool TryHandleItemAutomaticNull<TCollection, TItem>(
+        Check<TCollection> check,
+        TItem item,
+        int index
+    )
+    {
+        if (item is not null)
+        {
+            return false;
+        }
+
+        var itemContext = check.CreateChildContextForIndex(index);
+        var displayName = CreateIndexedDisplayName(check, index);
+
+        if (!itemContext.TryCreateAutomaticNullError(
+                item,
+                ValidationTarget.Relative(string.Empty, isNormalized: true),
+                displayName,
+                out var error
+            ))
+        {
+            return false;
+        }
+
+        itemContext.AddError(error);
+        return true;
     }
 
     private static Check<TItem> CreateItemCheck<TCollection, TItem>(Check<TCollection> check, TItem item, int index) =>

--- a/src/Light.PortableResults.Validation/Light.PortableResults.Validation.csproj
+++ b/src/Light.PortableResults.Validation/Light.PortableResults.Validation.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Framework-agnostic validation foundations for Light.PortableResults, including validation contexts, low-allocation checks, validator base classes, and validated value pipelines.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.Validation 0.3.0
+      Light.PortableResults.Validation 0.4.0
       ---------------------------------
 
       - Validation foundations with validation contexts, checks, validated value pipelines, and sync/async validator base classes.
       - Supports validation errors that integrate with Light.PortableResults HTTP and messaging transports.
-      - Validate your Microsoft.Extensions.Configuration options with Validator&lt;T>
+      - Validate your Microsoft.Extensions.Configuration options with Validator&lt;T>.
       - Compatible with .NET Native AOT.
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/Light.PortableResults.Validation/PortableResultsValidationModule.cs
+++ b/src/Light.PortableResults.Validation/PortableResultsValidationModule.cs
@@ -9,7 +9,7 @@ namespace Light.PortableResults.Validation;
 /// <summary>
 /// Provides integration into Microsoft.Extensions.DependencyInjection for Light.PortableResults.Validation.
 /// </summary>
-public static class Module
+public static class PortableResultsValidationModule
 {
     /// <summary>
     /// Adds Light.PortableResults.Validation services to the specified <see cref="IServiceCollection" />.

--- a/src/Light.PortableResults.Validation/PortableResultsValidationModule.cs
+++ b/src/Light.PortableResults.Validation/PortableResultsValidationModule.cs
@@ -12,15 +12,21 @@ namespace Light.PortableResults.Validation;
 public static class PortableResultsValidationModule
 {
     /// <summary>
-    /// Adds Light.PortableResults.Validation services to the specified <see cref="IServiceCollection" />.
-    /// Specifically, <see cref="IValidationContextFactory" /> is registered with <see cref="DefaultValidationContextFactory" />
-    /// as the implementation type and a singleton lifetime. <see cref="ValidationContextOptions" /> are added as options,
-    /// they are also made available as a singleton directly so that you don't need to resolve `IOptions&lt;ValidationContextOptions>`.
+    /// Registers the <see cref="IValidationContextFactory" /> and <see cref="ValidationContextOptions" /> as singletons
+    /// to the DI container when they have not been registered already.
     /// </summary>
     /// <param name="services">The service collection that holds all registrations.</param>
+    /// <param name="createOptions">
+    /// The optional delegate that creates the default <see cref="ValidationContextOptions"/> instance. The created
+    /// options are registered as a singleton (as the <see cref="IValidationContextFactory" /> itself is registered
+    /// as a singleton).
+    /// </param>
     /// <returns>The service collection for method-chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> is null.</exception>
-    public static IServiceCollection AddValidationForPortableResults(this IServiceCollection services)
+    public static IServiceCollection AddValidationForPortableResults(
+        this IServiceCollection services,
+        Func<IServiceProvider, ValidationContextOptions>? createOptions = null
+    )
     {
         if (services is null)
         {
@@ -28,10 +34,15 @@ public static class PortableResultsValidationModule
         }
 
         services.TryAddSingleton<IValidationContextFactory, DefaultValidationContextFactory>();
-        services.AddOptions<ValidationContextOptions>();
-        services.TryAddSingleton<ValidationContextOptions>(
-            sp => sp.GetRequiredService<IOptions<ValidationContextOptions>>().Value
-        );
+        if (createOptions is null)
+        {
+            services.TryAddSingleton<ValidationContextOptions>();
+        }
+        else
+        {
+            services.TryAddSingleton(createOptions);
+        }
+
         return services;
     }
 

--- a/src/Light.PortableResults/CloudEvents/Reading/PortableResultsCloudEventsReadOptions.cs
+++ b/src/Light.PortableResults/CloudEvents/Reading/PortableResultsCloudEventsReadOptions.cs
@@ -19,7 +19,7 @@ public sealed record PortableResultsCloudEventsReadOptions
     /// Gets or sets serializer options used to deserialize CloudEvents envelopes and data payloads.
     /// </summary>
     public JsonSerializerOptions SerializerOptions { get; init; } =
-        Module.DefaultSerializerOptions;
+        PortableResultsCloudEventsReadingModule.DefaultSerializerOptions;
 
     /// <summary>
     /// Gets or sets how successful generic payloads are interpreted.

--- a/src/Light.PortableResults/CloudEvents/Reading/PortableResultsCloudEventsReadingModule.cs
+++ b/src/Light.PortableResults/CloudEvents/Reading/PortableResultsCloudEventsReadingModule.cs
@@ -12,7 +12,7 @@ namespace Light.PortableResults.CloudEvents.Reading;
 /// <summary>
 /// Provides methods to register services required for CloudEvents reading.
 /// </summary>
-public static class Module
+public static class PortableResultsCloudEventsReadingModule
 {
     /// <summary>
     /// Gets the default serializer options used by Light.PortableResults CloudEvents reading.

--- a/src/Light.PortableResults/CloudEvents/Writing/PortableResultsCloudEventsWriteOptions.cs
+++ b/src/Light.PortableResults/CloudEvents/Writing/PortableResultsCloudEventsWriteOptions.cs
@@ -29,7 +29,8 @@ public sealed record PortableResultsCloudEventsWriteOptions
     /// <summary>
     /// Gets or sets serializer options used for result value serialization.
     /// </summary>
-    public JsonSerializerOptions SerializerOptions { get; set; } = Module.DefaultSerializerOptions;
+    public JsonSerializerOptions SerializerOptions { get; set; } =
+        PortableResultsCloudEventsWritingModule.DefaultSerializerOptions;
 
     /// <summary>
     /// Gets or sets the conversion service used to map metadata entries to CloudEvents attributes.

--- a/src/Light.PortableResults/CloudEvents/Writing/PortableResultsCloudEventsWritingModule.cs
+++ b/src/Light.PortableResults/CloudEvents/Writing/PortableResultsCloudEventsWritingModule.cs
@@ -12,7 +12,7 @@ namespace Light.PortableResults.CloudEvents.Writing;
 /// <summary>
 /// Provides methods to register services required for CloudEvents writing.
 /// </summary>
-public static class Module
+public static class PortableResultsCloudEventsWritingModule
 {
     /// <summary>
     /// Gets the default serializer options used by Light.PortableResults CloudEvents writing.

--- a/src/Light.PortableResults/Http/Reading/PortableResultsHttpReadOptions.cs
+++ b/src/Light.PortableResults/Http/Reading/PortableResultsHttpReadOptions.cs
@@ -41,5 +41,6 @@ public sealed record PortableResultsHttpReadOptions
     /// <summary>
     /// Gets or sets serializer options used to deserialize Result payloads with <see cref="JsonSerializer" />.
     /// </summary>
-    public JsonSerializerOptions SerializerOptions { get; init; } = Module.DefaultSerializerOptions;
+    public JsonSerializerOptions SerializerOptions { get; init; } =
+        PortableResultsHttpReadingModule.DefaultSerializerOptions;
 }

--- a/src/Light.PortableResults/Http/Reading/PortableResultsHttpReadingModule.cs
+++ b/src/Light.PortableResults/Http/Reading/PortableResultsHttpReadingModule.cs
@@ -9,7 +9,7 @@ namespace Light.PortableResults.Http.Reading;
 /// <summary>
 /// Provides methods to register services and JSON configuration for Light.PortableResults HTTP reading.
 /// </summary>
-public static class Module
+public static class PortableResultsHttpReadingModule
 {
     /// <summary>
     /// Gets the default serializer options used by Light.PortableResults HTTP response reading.

--- a/src/Light.PortableResults/Http/Writing/PortableResultsHttpWritingModule.cs
+++ b/src/Light.PortableResults/Http/Writing/PortableResultsHttpWritingModule.cs
@@ -13,7 +13,7 @@ namespace Light.PortableResults.Http.Writing;
 /// <summary>
 /// Provides methods to register services required for Light.PortableResults HTTP writing.
 /// </summary>
-public static class Module
+public static class PortableResultsHttpWritingModule
 {
     /// <summary>
     /// Registers <see cref="PortableResultsHttpWriteOptions" /> in the service container.

--- a/src/Light.PortableResults/Light.PortableResults.csproj
+++ b/src/Light.PortableResults/Light.PortableResults.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>The Light.PortableResults package implements the core functionality: Results, Errors, Metadata, Functional Extensions, and serialization support for various formats like HTTP and CloudEvents. Compatible with Native AOT. Check out the integration packages Light.PortableResults.AspNetCore.MinimalApis or Light.PortableResults.AspNetCore.Mvc.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults 0.3.0
+      Light.PortableResults 0.4.0
       ---------------------------------
 
       - Contains core functionality: Results, Errors, Metadata, Functional Extensions, and JSON serialization support for HTTP and CloudEvents.

--- a/tests/Light.PortableResults.Tests/CloudEvents/Reading/PortableResultsCloudEventsReadingModuleTests.cs
+++ b/tests/Light.PortableResults.Tests/CloudEvents/Reading/PortableResultsCloudEventsReadingModuleTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Light.PortableResults.Tests.CloudEvents.Reading;
 
-public sealed class ModuleTests
+public sealed class PortableResultsCloudEventsReadingModuleTests
 {
     [Fact]
     public void AddPortableResultsCloudEventsReadOptions_ShouldRegisterOptions()

--- a/tests/Light.PortableResults.Tests/CloudEvents/Writing/PortableResultsCloudEventsWritingModuleTests.cs
+++ b/tests/Light.PortableResults.Tests/CloudEvents/Writing/PortableResultsCloudEventsWritingModuleTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Light.PortableResults.Tests.CloudEvents.Writing;
 
-public sealed class ModuleTests
+public sealed class PortableResultsCloudEventsWritingModuleTests
 {
     [Fact]
     public void AddPortableResultsCloudEventsWriteOptions_ShouldRegisterOptions()
@@ -28,7 +28,7 @@ public sealed class ModuleTests
         options.Source.Should().BeNull();
         options.MetadataSerializationMode.Should().Be(MetadataSerializationMode.Always);
         options.ConversionService.Should().BeSameAs(DefaultCloudEventsAttributeConversionService.Instance);
-        options.SerializerOptions.Should().BeSameAs(Module.DefaultSerializerOptions);
+        options.SerializerOptions.Should().BeSameAs(PortableResultsCloudEventsWritingModule.DefaultSerializerOptions);
     }
 
     [Fact]

--- a/tests/Light.PortableResults.Tests/Http/JsonConverterDirectionTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/JsonConverterDirectionTests.cs
@@ -2,12 +2,12 @@ using System;
 using System.IO;
 using System.Text.Json;
 using FluentAssertions;
+using Light.PortableResults.Http.Reading;
 using Light.PortableResults.Http.Reading.Json;
 using Light.PortableResults.Http.Writing;
 using Light.PortableResults.Http.Writing.Json;
 using Light.PortableResults.Metadata;
 using Xunit;
-using Module = Light.PortableResults.Http.Reading.Module;
 
 namespace Light.PortableResults.Tests.Http;
 
@@ -104,7 +104,7 @@ public sealed class JsonConverterDirectionTests
     public void HttpReadAutoSuccessPayloadConverter_ShouldReadPayload()
     {
         var converter = new HttpReadAutoSuccessResultPayloadJsonConverter<int>();
-        var options = Module.CreateDefaultSerializerOptions();
+        var options = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
         var reader = new Utf8JsonReader("""{"value":42,"metadata":{"source":"auto"}}"""u8);
 
         var payload = converter.Read(ref reader, typeof(HttpReadAutoSuccessResultPayload<int>), options);
@@ -131,7 +131,7 @@ public sealed class JsonConverterDirectionTests
     public void HttpReadBareSuccessPayloadConverter_ShouldReadPayload()
     {
         var converter = new HttpReadBareSuccessResultPayloadJsonConverter<int>();
-        var options = Module.CreateDefaultSerializerOptions();
+        var options = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
         var reader = new Utf8JsonReader("42"u8);
 
         var payload = converter.Read(ref reader, typeof(HttpReadBareSuccessResultPayload<int>), options);
@@ -157,7 +157,7 @@ public sealed class JsonConverterDirectionTests
     public void HttpReadWrappedSuccessPayloadConverter_ShouldReadPayload()
     {
         var converter = new HttpReadWrappedSuccessResultPayloadJsonConverter<int>();
-        var options = Module.CreateDefaultSerializerOptions();
+        var options = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
         var reader = new Utf8JsonReader("""{"value":42,"metadata":{"source":"wrapped"}}"""u8);
 
         var payload = converter.Read(ref reader, typeof(HttpReadWrappedSuccessResultPayload<int>), options);
@@ -249,11 +249,14 @@ public sealed class JsonConverterDirectionTests
         factory.CanConvert(typeof(HttpReadBareSuccessResultPayload<int>)).Should().BeTrue();
         factory.CanConvert(typeof(HttpReadWrappedSuccessResultPayload<int>)).Should().BeTrue();
         factory.CanConvert(typeof(HttpReadSuccessResultPayload)).Should().BeFalse();
-        factory.CreateConverter(typeof(HttpReadAutoSuccessResultPayload<int>), new JsonSerializerOptions())
+        factory
+           .CreateConverter(typeof(HttpReadAutoSuccessResultPayload<int>), new JsonSerializerOptions())
            .Should().BeOfType<HttpReadAutoSuccessResultPayloadJsonConverter<int>>();
-        factory.CreateConverter(typeof(HttpReadBareSuccessResultPayload<int>), new JsonSerializerOptions())
+        factory
+           .CreateConverter(typeof(HttpReadBareSuccessResultPayload<int>), new JsonSerializerOptions())
            .Should().BeOfType<HttpReadBareSuccessResultPayloadJsonConverter<int>>();
-        factory.CreateConverter(typeof(HttpReadWrappedSuccessResultPayload<int>), new JsonSerializerOptions())
+        factory
+           .CreateConverter(typeof(HttpReadWrappedSuccessResultPayload<int>), new JsonSerializerOptions())
            .Should().BeOfType<HttpReadWrappedSuccessResultPayloadJsonConverter<int>>();
     }
 
@@ -264,7 +267,8 @@ public sealed class JsonConverterDirectionTests
 
         factory.CanConvert(typeof(HttpResultForWriting<int>)).Should().BeTrue();
         factory.CanConvert(typeof(HttpResultForWriting)).Should().BeFalse();
-        factory.CreateConverter(typeof(HttpResultForWriting<int>), new JsonSerializerOptions())
+        factory
+           .CreateConverter(typeof(HttpResultForWriting<int>), new JsonSerializerOptions())
            .Should().BeOfType<HttpResultForWritingJsonConverter<int>>();
     }
 }

--- a/tests/Light.PortableResults.Tests/Http/Reading/HttpResponseMessageExtensionsTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/Reading/HttpResponseMessageExtensionsTests.cs
@@ -136,7 +136,7 @@ public sealed class HttpResponseMessageExtensionsTests
     public async Task ReadResultAsyncOfT_ShouldThrow_WhenBarePayloadConverterProducesNullValue()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
         serializerOptions.Converters.Insert(0, new NullBareStringPayloadConverter());
 
         var options = new PortableResultsHttpReadOptions
@@ -157,7 +157,7 @@ public sealed class HttpResponseMessageExtensionsTests
     public async Task ReadResultAsync_ShouldThrow_WhenFailurePayloadConverterProducesNoErrors()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
         serializerOptions.Converters.Insert(0, new EmptyFailurePayloadConverter());
 
         var options = new PortableResultsHttpReadOptions

--- a/tests/Light.PortableResults.Tests/Http/Reading/PortableResultsHttpReadingModuleTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/Reading/PortableResultsHttpReadingModuleTests.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace Light.PortableResults.Tests.Http.Reading;
 
-public sealed class ModuleTests
+public sealed class PortableResultsHttpReadingModuleTests
 {
     [Fact]
     public void AddDefaultPortableResultsHttpReadJsonConverters_ShouldThrow_WhenSerializerOptionsAreNull()
     {
-        var act = () => Module.AddDefaultPortableResultsHttpReadJsonConverters(null!);
+        var act = () => PortableResultsHttpReadingModule.AddDefaultPortableResultsHttpReadJsonConverters(null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
@@ -44,7 +44,7 @@ public sealed class ModuleTests
     [Fact]
     public void CreateDefaultPortableResultsHttpReadJsonSerializerOptions_ShouldDeserializeGenericAutoPayload()
     {
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
 
         var payload =
             JsonSerializer.Deserialize<HttpReadAutoSuccessResultPayload<int>>("{\"value\":42}", serializerOptions);
@@ -56,7 +56,7 @@ public sealed class ModuleTests
     [Fact]
     public void CreateDefaultPortableResultsHttpReadJsonSerializerOptions_ShouldDeserializeNonGenericSuccessPayload()
     {
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
 
         var payload = JsonSerializer.Deserialize<HttpReadSuccessResultPayload>(
             "{\"metadata\":{\"source\":\"module\"}}",
@@ -69,7 +69,7 @@ public sealed class ModuleTests
     [Fact]
     public void CreateDefaultPortableResultsHttpReadJsonSerializerOptions_ShouldDeserializeFailurePayload()
     {
-        var serializerOptions = Module.CreateDefaultSerializerOptions();
+        var serializerOptions = PortableResultsHttpReadingModule.CreateDefaultSerializerOptions();
 
         var payload = JsonSerializer.Deserialize<HttpReadFailureResultPayload>(
             """
@@ -104,6 +104,6 @@ public sealed class ModuleTests
         var options = provider.GetRequiredService<PortableResultsHttpReadOptions>();
 
         options.Should().NotBeNull();
-        options.SerializerOptions.Should().BeSameAs(Module.DefaultSerializerOptions);
+        options.SerializerOptions.Should().BeSameAs(PortableResultsHttpReadingModule.DefaultSerializerOptions);
     }
 }

--- a/tests/Light.PortableResults.Tests/Http/Writing/PortableResultsHttpWritingModuleTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/Writing/PortableResultsHttpWritingModuleTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Light.PortableResults.Tests.Http.Writing;
 
-public sealed class ModuleTests
+public sealed class PortableResultsHttpWritingModuleTests
 {
     [Fact]
     public void AddPortableResultsHttpHeaderConversionService_ShouldUseComparerForKeys()
@@ -44,7 +44,7 @@ public sealed class ModuleTests
     [Fact]
     public void AddDefaultPortableResultsJsonConverters_ShouldThrow_WhenSerializerOptionsIsNull()
     {
-        var act = () => Module.AddDefaultPortableResultsHttpWriteJsonConverters(null!);
+        var act = () => PortableResultsHttpWritingModule.AddDefaultPortableResultsHttpWriteJsonConverters(null!);
 
         act.Should().Throw<ArgumentNullException>().Where(x => x.ParamName == "serializerOptions");
     }

--- a/tests/Light.PortableResults.Validation.Tests/CollectionValidationWorkflowTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/CollectionValidationWorkflowTests.cs
@@ -1118,6 +1118,187 @@ public sealed class CollectionValidationWorkflowTests
         context.Errors.Should().BeEmpty();
     }
 
+    [Fact]
+    public void ValidateItems_ShouldAddAutomaticNullError_WhenItemIsNullAndUsingActionDelegate()
+    {
+        var context = ValidationWorkflowTestData.ValidationContextFactory.CreateValidationContext();
+        var items = new List<string?> { "valid", null };
+        var invocationCount = 0;
+
+        var result = context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItems(
+                (Action<Check<string?>>) (_ => invocationCount++)
+            );
+
+        result.Should().Be(ValidatedValue<List<string?>>.NoValue);
+        invocationCount.Should().Be(1);
+        context.Errors.Should().Equal(new Errors(CreateAutomaticNullError("Items[1]", "items[1]")));
+    }
+
+    [Fact]
+    public void ValidateItems_ShouldPassNullItemToDelegate_WhenProviderDeclinesItemNullErrorAndUsingActionDelegate()
+    {
+        var context = CreateContextWithoutAutomaticNullErrors();
+        var items = new List<string?> { null };
+        var capturedValue = "sentinel";
+
+        var result = context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItems(
+                (Action<Check<string?>>) (itemCheck => capturedValue = itemCheck.Value)
+            );
+
+        result.TryGetValue(out _).Should().BeTrue();
+        capturedValue.Should().BeNull();
+        context.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateItems_ShouldAddAutomaticNullError_WhenItemIsNullAndUsingNormalizingDelegate()
+    {
+        var context = ValidationWorkflowTestData.ValidationContextFactory.CreateValidationContext();
+        var items = new List<string?> { "valid", null };
+        var invocationCount = 0;
+
+        var result = context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItems(
+                (Func<Check<string?>, ValidatedValue<string?>>) (itemCheck =>
+                {
+                    invocationCount++;
+                    return ValidatedValue.Success(itemCheck.Value);
+                })
+            );
+
+        result.Should().Be(ValidatedValue<List<string?>>.NoValue);
+        invocationCount.Should().Be(1);
+        context.Errors.Should().Equal(new Errors(CreateAutomaticNullError("Items[1]", "items[1]")));
+    }
+
+    [Fact]
+    public void
+        ValidateItems_ShouldPassNullItemToDelegate_WhenProviderDeclinesItemNullErrorAndUsingNormalizingDelegate()
+    {
+        var context = CreateContextWithoutAutomaticNullErrors();
+        var items = new List<string?> { null };
+        var capturedValue = "sentinel";
+
+        var result = context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItems(
+                (Func<Check<string?>, ValidatedValue<string?>>) (itemCheck =>
+                {
+                    capturedValue = itemCheck.Value;
+                    return ValidatedValue<string?>.NoValue;
+                })
+            );
+
+        result.TryGetValue(out _).Should().BeTrue();
+        capturedValue.Should().BeNull();
+        context.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateItemsAsync_ShouldAddAutomaticNullError_WhenItemIsNullAndUsingActionDelegate()
+    {
+        var context = ValidationWorkflowTestData.ValidationContextFactory.CreateValidationContext();
+        var items = new List<string?> { "valid", null };
+        var invocationCount = 0;
+
+        var result = await context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItemsAsync<List<string?>, string?>(
+                async (_, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    invocationCount++;
+                },
+                TestContext.Current.CancellationToken
+            );
+
+        result.Should().Be(ValidatedValue<List<string?>>.NoValue);
+        invocationCount.Should().Be(1);
+        context.Errors.Should().Equal(new Errors(CreateAutomaticNullError("Items[1]", "items[1]")));
+    }
+
+    [Fact]
+    public async Task
+        ValidateItemsAsync_ShouldPassNullItemToDelegate_WhenProviderDeclinesItemNullErrorAndUsingActionDelegate()
+    {
+        var context = CreateContextWithoutAutomaticNullErrors();
+        var items = new List<string?> { null };
+        var capturedValue = "sentinel";
+
+        var result = await context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItemsAsync<List<string?>, string?>(
+                async (itemCheck, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    capturedValue = itemCheck.Value;
+                },
+                TestContext.Current.CancellationToken
+            );
+
+        result.TryGetValue(out _).Should().BeTrue();
+        capturedValue.Should().BeNull();
+        context.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ValidateItemsAsync_ShouldAddAutomaticNullError_WhenItemIsNullAndUsingNormalizingDelegate()
+    {
+        var context = ValidationWorkflowTestData.ValidationContextFactory.CreateValidationContext();
+        var items = new List<string?> { "valid", null };
+        var invocationCount = 0;
+
+        var result = await context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItemsAsync<List<string?>, string?>(
+                async (itemCheck, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    invocationCount++;
+                    return ValidatedValue.Success(itemCheck.Value);
+                },
+                TestContext.Current.CancellationToken
+            );
+
+        result.Should().Be(ValidatedValue<List<string?>>.NoValue);
+        invocationCount.Should().Be(1);
+        context.Errors.Should().Equal(new Errors(CreateAutomaticNullError("Items[1]", "items[1]")));
+    }
+
+    [Fact]
+    public async Task
+        ValidateItemsAsync_ShouldPassNullItemToDelegate_WhenProviderDeclinesItemNullErrorAndUsingNormalizingDelegate()
+    {
+        var context = CreateContextWithoutAutomaticNullErrors();
+        var items = new List<string?> { null };
+        var capturedValue = "sentinel";
+
+        var result = await context
+           .Check(items, target: "request.Items", displayName: "Items")
+           .ValidateItemsAsync<List<string?>, string?>(
+                async (itemCheck, cancellationToken) =>
+                {
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    capturedValue = itemCheck.Value;
+                    return ValidatedValue<string?>.NoValue;
+                },
+                TestContext.Current.CancellationToken
+            );
+
+        result.TryGetValue(out _).Should().BeTrue();
+        capturedValue.Should().BeNull();
+        context.Errors.Should().BeEmpty();
+    }
+
     private static Error CreateAutomaticNullError(string displayName, string target) =>
         ValidationWorkflowTestData.CreateValidationError($"{displayName} must not be null", "NotNull", target);
 

--- a/tests/Light.PortableResults.Validation.Tests/PortableResultsValidationModuleTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/PortableResultsValidationModuleTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Light.PortableResults.Validation.Tests;
 
-public sealed class ModuleTests
+public sealed class PortableResultsValidationModuleTests
 {
     [Fact]
     public void AddValidationForPortableResults_ShouldThrowArgumentNullException_WhenServicesIsNull()

--- a/tests/Light.PortableResults.Validation.Tests/PortableResultsValidationModuleTests.cs
+++ b/tests/Light.PortableResults.Validation.Tests/PortableResultsValidationModuleTests.cs
@@ -57,9 +57,8 @@ public sealed class PortableResultsValidationModuleTests
         using var provider = CreateDefaultProvider();
 
         var directOptions = provider.GetRequiredService<ValidationContextOptions>();
-        var optionsFromIOptions = provider.GetRequiredService<IOptions<ValidationContextOptions>>().Value;
 
-        directOptions.Should().BeSameAs(optionsFromIOptions);
+        directOptions.Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
This PR does several things:

- BREAKING: `ValidationContextOptions` are no longer registered using the Options Pattern. They are immutable and thus cannot meaningfully participate in `services.Configure` or `IOptionsBuilder<T>` calls. There are now simply registered as a singleton.
- All `ValidateItems` and `ValidateItemsAsync` overloads now participate correctly in Automatic Null Checking.
- BREAKING: All `Module` classes were renamed so that they have speaking names
- Updated README.md with newest changes, including release notes for 0.4.0
