### PR TITLE
Decimal Metadata Kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,3 @@ Read ./ai-plans/AGENTS.md for details on how to write plans.
 ## Here is Your Space
 
 If you encounter something worth noting while you are working on this code base, write it down here in this section. Once you are finished, I will discuss it with you, and we can decide where to put your notes.
-
-### Notes from plan 0052 (decimal metadata kind)
-
-- Solution-wide line coverage sits right on the 95% threshold (94.8% before this plan, 95.0% after). The margin comes from `Light.PortableResults.AspNetCore.MinimalApis` (87.6%), `Light.PortableResults.AspNetCore.Mvc` (87.9%), and `Light.PortableResults.Validation.OpenApi.SourceGeneration` (87%), while the core package is at 96.2%. Any future plan whose acceptance criteria include the 95% gate will be paying off that debt rather than covering its own code. Worth deciding whether the gate should be per-assembly.
-- `MetadataValueTestFactory` (in `Light.PortableResults.Tests/Metadata`) builds a `MetadataValue` with an undeclared `MetadataKind` via reflection on the private constructor. It is the only way to reach the fallback arms of the kind dispatch sites. If the constructor signature changes, that helper and `UndeclaredMetadataKindFallbackTests` break.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,8 @@ Read ./ai-plans/AGENTS.md for details on how to write plans.
 ## Here is Your Space
 
 If you encounter something worth noting while you are working on this code base, write it down here in this section. Once you are finished, I will discuss it with you, and we can decide where to put your notes.
+
+### Notes from plan 0052 (decimal metadata kind)
+
+- Solution-wide line coverage sits right on the 95% threshold (94.8% before this plan, 95.0% after). The margin comes from `Light.PortableResults.AspNetCore.MinimalApis` (87.6%), `Light.PortableResults.AspNetCore.Mvc` (87.9%), and `Light.PortableResults.Validation.OpenApi.SourceGeneration` (87%), while the core package is at 96.2%. Any future plan whose acceptance criteria include the 95% gate will be paying off that debt rather than covering its own code. Worth deciding whether the gate should be per-assembly.
+- `MetadataValueTestFactory` (in `Light.PortableResults.Tests/Metadata`) builds a `MetadataValue` with an undeclared `MetadataKind` via reflection on the private constructor. It is the only way to reach the fallback arms of the kind dispatch sites. If the constructor signature changes, that helper and `UndeclaredMetadataKindFallbackTests` break.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Authors>Kenny Pflug</Authors>
     <Company>Kenny Pflug</Company>
     <Copyright>Copyright (c) 2026 Kenny Pflug</Copyright>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *The Result Pattern for .NET that travels. Every `Result<T>` serializes reliably over HTTP (with RFC-9457 Problem Details support), CloudEvents, and back — with a validation framework that is at least 5x faster and uses less than 9% of the memory of FluentValidation.*
 
 [![License](https://img.shields.io/badge/License-MIT-green.svg?style=for-the-badge)](https://github.com/feO2x/Light.PortableResults/blob/main/LICENSE)
-[![NuGet](https://img.shields.io/badge/NuGet-0.6.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages?q=Light.PortableResults)
+[![NuGet](https://img.shields.io/badge/NuGet-0.7.0-blue.svg?style=for-the-badge)](https://www.nuget.org/packages?q=Light.PortableResults)
 [![Documentation](https://img.shields.io/badge/Docs-Changelog-yellowgreen.svg?style=for-the-badge)](https://github.com/feO2x/Light.PortableResults/releases)
 
 Most Result Pattern libraries stop at the application boundary. Light.PortableResults does not: a `Result<T>` can be written as an HTTP response (including RFC-9457 Problem Details support), published as a CloudEvents JSON message, read back from both protocols on the other side, and arrive as a fully-typed `Result<T>` — without losing errors, metadata, or structure. If you also need validation, the built-in framework lets you write FluentValidation-style rules with a fraction of the allocations. Plus: Roslyn Source Generators write OpenAPI error schemas and examples for you.

--- a/ai-plans/0052-decimal-metadata-kind.md
+++ b/ai-plans/0052-decimal-metadata-kind.md
@@ -8,19 +8,19 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 
 ## Acceptance Criteria
 
-- [ ] `MetadataValue.FromDecimal` produces a value whose `Kind` is `MetadataKind.Decimal`.
-- [ ] A decimal metadata value is written into JSON bodies as an unquoted JSON number that preserves all significant digits and the original scale.
-- [ ] A `problem+json` body produced by a comparison or range validation rule on a decimal-typed value conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
-- [ ] `MetadataKind.Decimal` is classified as primitive, so decimals remain valid inside arrays annotated for header serialization and valid as CloudEvents extension attributes.
-- [ ] Every declared `MetadataKind` member is asserted to be classified correctly as primitive or complex by a test that enumerates the enum, so a member declared outside the reserved primitive range fails the build.
-- [ ] `TryGetDecimal` returns the stored value for `MetadataKind.Decimal` without parsing text, and continues to convert from `Int64`, `Double`, and numeric strings.
-- [ ] `TryGetString` returns `false` for a decimal metadata value.
-- [ ] `MetadataValue.ToString()` renders decimals as unquoted invariant-culture numeric text.
-- [ ] A decimal metadata value resolves correctly when used as a CloudEvents core string attribute instead of silently becoming `null`.
-- [ ] HTTP header formatting emits decimals without quote characters.
-- [ ] The JSON reader's treatment of numeric tokens is explicitly specified and covered by tests, including the documented cases where a decimal does not read back as `MetadataKind.Decimal`.
-- [ ] A test pins `Unsafe.SizeOf<MetadataValue>()` to the value it has before this plan, so any future change to the payload layout has to be deliberate.
-- [ ] Test code coverage stays above 95%.
+- [x] `MetadataValue.FromDecimal` produces a value whose `Kind` is `MetadataKind.Decimal`.
+- [x] A decimal metadata value is written into JSON bodies as an unquoted JSON number that preserves all significant digits and the original scale.
+- [x] A `problem+json` body produced by a comparison or range validation rule on a decimal-typed value conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
+- [x] `MetadataKind.Decimal` is classified as primitive, so decimals remain valid inside arrays annotated for header serialization and valid as CloudEvents extension attributes.
+- [x] Every declared `MetadataKind` member is asserted to be classified correctly as primitive or complex by a test that enumerates the enum, so a member declared outside the reserved primitive range fails the build.
+- [x] `TryGetDecimal` returns the stored value for `MetadataKind.Decimal` without parsing text, and continues to convert from `Int64`, `Double`, and numeric strings.
+- [x] `TryGetString` returns `false` for a decimal metadata value.
+- [x] `MetadataValue.ToString()` renders decimals as unquoted invariant-culture numeric text.
+- [x] A decimal metadata value resolves correctly when used as a CloudEvents core string attribute instead of silently becoming `null`.
+- [x] HTTP header formatting emits decimals without quote characters.
+- [x] The JSON reader's treatment of numeric tokens is explicitly specified and covered by tests, including the documented cases where a decimal does not read back as `MetadataKind.Decimal`.
+- [x] A test pins `Unsafe.SizeOf<MetadataValue>()` to the value it has before this plan, so any future change to the payload layout has to be deliberate.
+- [x] Test code coverage stays above 95%.
 
 ## Technical Details
 

--- a/ai-plans/0052-decimal-metadata-kind.md
+++ b/ai-plans/0052-decimal-metadata-kind.md
@@ -40,9 +40,9 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 public enum MetadataKind : byte
 {
     Null = 0, Boolean = 1, Int64 = 2, Double = 3, String = 4, Decimal = 5,
-    // 6-99 are reserved for future primitive kinds
-    Array = 100,
-    Object = 101
+    // 6-199 are reserved for future primitive kinds
+    Array = 200,
+    Object = 201
 }
 ```
 
@@ -86,7 +86,7 @@ The library is pre-1.0 and breaking changes are permitted, but these are silent 
 
 - `TryGetString` no longer returns `true` for decimals.
 - `Kind` for a decimal is no longer `MetadataKind.String`.
-- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` change to `100` and `101`. No code in the solution casts `MetadataKind` to a numeric type and the enum is not exposed by the OpenAPI, Validation, or source-generation packages, so this is invisible today — but any consumer that persisted or transmitted the numeric value is affected.
+- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` change to `200` and `201`. No code in the solution casts `MetadataKind` to a numeric type and the enum is not exposed by the OpenAPI, Validation, or source-generation packages, so this is invisible today — but any consumer that persisted or transmitted the numeric value is affected.
 - Decimal metadata appears as a JSON number rather than a JSON string in serialized bodies.
 - Decimals differing only in trailing zeros now compare equal.
 

--- a/ai-plans/0052-decimal-metadata-kind.md
+++ b/ai-plans/0052-decimal-metadata-kind.md
@@ -2,7 +2,7 @@
 
 ## Rationale
 
-`MetadataValue.FromDecimal` converts its input to invariant text and stores `MetadataKind.String`. Decimals therefore serialize into JSON bodies as quoted strings, while `PortableOpenApiSchemaTypeMapper` maps `decimal` to `JsonSchemaType.Number` and `PortableResultsOpenApiDocumentTransformer` emits decimal examples as unquoted numbers. The published contract and the runtime payload disagree. The mismatch is reachable through the built-in validation error definitions, which route every `TypeCode.Decimal` parameter through `FromDecimal`, so any decimal precision-and-scale rule produces a `problem+json` body that violates the OpenAPI document generated for the same endpoint.
+`MetadataValue.FromDecimal` converts its input to invariant text and stores `MetadataKind.String`. Decimals therefore serialize into JSON bodies as quoted strings, while `PortableOpenApiSchemaTypeMapper` maps `decimal` to `JsonSchemaType.Number` and `PortableResultsOpenApiDocumentTransformer` emits decimal examples as unquoted numbers. The published contract and the runtime payload disagree. The mismatch is reachable through the built-in validation error definitions: `CreateMetadataValue<T>` routes every `TypeCode.Decimal` parameter through `FromDecimal`, and it backs the `ComparativeValue`, `LowerBoundary`, and `UpperBoundary` metadata keys. Any comparison or range check on a decimal-typed value — `IsGreaterThan(19.99m)`, `IsInRange(9.99m, 99.99m)` — therefore produces a `problem+json` body that violates the OpenAPI document generated for the same endpoint.
 
 Storing decimals as text also loses type information (a decimal is indistinguishable from a numeric-looking string), forces `TryGetDecimal` to run `decimal.TryParse` on every call, and allocates more than necessary. This plan introduces a dedicated `MetadataKind.Decimal` backed by a boxed `decimal`.
 
@@ -10,7 +10,7 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 
 - [ ] `MetadataValue.FromDecimal` produces a value whose `Kind` is `MetadataKind.Decimal`.
 - [ ] A decimal metadata value is written into JSON bodies as an unquoted JSON number that preserves all significant digits and the original scale.
-- [ ] A `problem+json` body produced by a decimal precision-and-scale validation rule conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
+- [ ] A `problem+json` body produced by a comparison or range validation rule on a decimal-typed value conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
 - [ ] `MetadataKind.Decimal` is classified as primitive, so decimals remain valid inside arrays annotated for header serialization and valid as CloudEvents extension attributes.
 - [ ] Every declared `MetadataKind` member is asserted to be classified correctly as primitive or complex by a test that enumerates the enum, so a member declared outside the reserved primitive range fails the build.
 - [ ] `TryGetDecimal` returns the stored value for `MetadataKind.Decimal` without parsing text, and continues to convert from `Int64`, `Double`, and numeric strings.
@@ -19,7 +19,7 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 - [ ] A decimal metadata value resolves correctly when used as a CloudEvents core string attribute instead of silently becoming `null`.
 - [ ] HTTP header formatting emits decimals without quote characters.
 - [ ] The JSON reader's treatment of numeric tokens is explicitly specified and covered by tests, including the documented cases where a decimal does not read back as `MetadataKind.Decimal`.
-- [ ] `Unsafe.SizeOf<MetadataValue>()` is unchanged from before this plan, asserted by a test that pins the current value.
+- [ ] A test pins `Unsafe.SizeOf<MetadataValue>()` to the value it has before this plan, so any future change to the payload layout has to be deliberate.
 - [ ] Test code coverage stays above 95%.
 
 ## Technical Details
@@ -63,14 +63,20 @@ The default is chosen. Preferring `Decimal` unconditionally would make the resul
 
 This plan therefore improves **outbound** fidelity. It deliberately does not claim that a decimal round-trips as a decimal; that limitation is inherent to untyped numeric wire formats and is the same constraint recorded for HTTP headers in `0051`. Acceptance criteria must not assert round-trip symmetry for decimals.
 
-### Affected components
+### Affected components: there is no compile-time safety net
 
-Only two exhaustive `MetadataKind` switches exist outside the `Metadata` folder, and both fail to compile without a new branch:
+Every site that dispatches on `MetadataKind` has a `default` arm or a silent fall-through, so **adding the enum member breaks nothing at compile time**. A partial implementation ships silent data corruption rather than a build error. Each of these must be updated deliberately:
 
-- `SharedJsonSerialization/Writing/MetadataExtensions.WriteMetadataValue` — write via `WriteNumberValue(decimal)`.
-- `CloudEvents/MetadataValueAnnotationHelper`.
+| Site | Behaviour if left unhandled | Detected |
+| --- | --- | --- |
+| `SharedJsonSerialization/Writing/MetadataExtensions.WriteMetadataValue` | `default:` writes `WriteNullValue()` — a decimal serializes as JSON `null` | Silent |
+| `MetadataValue.Equals` | `_ => false` — a decimal never equals another decimal | Silent |
+| `MetadataValue.GetHashCode` | no `default` and no case — every decimal hashes to the kind alone | Silent |
+| `CloudEventsResultExtensions.GetStringAttribute` | `if`-chain falls through to `null` — a decimal-valued `subject`, `type`, or `source` becomes `null` | Silent |
+| `CloudEvents/MetadataValueAnnotationHelper.WithAnnotation` | `default:` throws `ArgumentOutOfRangeException` | Runtime |
+| `MetadataValue.ToString()` | `_ =>` throws `InvalidOperationException` | Runtime |
 
-The dangerous case is `CloudEventsResultExtensions.GetStringAttribute`, which is an `if`-chain over `TryGetString`/`TryGetBoolean`/`TryGetInt64`/`TryGetDouble` falling through to `null`. Today a decimal is caught by the `TryGetString` branch. After this change it falls through and a decimal-valued `subject`, `type`, or `source` silently becomes `null` instead of resolving or throwing. This is a behavioural regression the compiler will not surface.
+Two of these are worse than the defect being fixed. `WriteNullValue()` replaces a quoted string with `null`, losing the value entirely. `Equals` returning `false` alongside a kind-only hash breaks `MetadataObject` and dictionary lookups for decimals without any error surfacing.
 
 Everything else reaches decimals through `IsPrimitive` or the `TryGet*` accessors and needs no change.
 
@@ -98,7 +104,9 @@ This plan should land before `0051-http-header-value-formatting`. That plan's ki
 
 `MetadataValueTests.FromDecimal_ShouldStoreAsString` inverts and must be renamed alongside its assertions. `MetadataObjectTests` and `MetadataValueAnnotationTests` also construct decimal values and need review.
 
-Beyond the unit-level kind matrix, the criterion that carries the actual defect is the OpenAPI conformance test: trigger a decimal precision-and-scale validation failure through an integration test app and assert that the raw `problem+json` body contains an unquoted number for the precision and scale metadata.
+Because no dispatch site fails to compile, the kind matrix must be exercised explicitly for every site in the table above rather than relying on the build. Equality and hashing in particular need a test that puts decimals into a `MetadataObject` and reads them back, since the failure there is silent in both directions.
+
+Beyond the unit-level matrix, the criterion that carries the actual defect is the OpenAPI conformance test: trigger a comparison or range validation failure on a decimal-typed value through an integration test app and assert that the raw `problem+json` body carries an unquoted number for the `ComparativeValue` or boundary metadata.
 
 ### Out of scope
 

--- a/ai-plans/0052-decimal-metadata-kind.md
+++ b/ai-plans/0052-decimal-metadata-kind.md
@@ -12,6 +12,7 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 - [ ] A decimal metadata value is written into JSON bodies as an unquoted JSON number that preserves all significant digits and the original scale.
 - [ ] A `problem+json` body produced by a decimal precision-and-scale validation rule conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
 - [ ] `MetadataKind.Decimal` is classified as primitive, so decimals remain valid inside arrays annotated for header serialization and valid as CloudEvents extension attributes.
+- [ ] Every declared `MetadataKind` member is asserted to be classified correctly as primitive or complex by a test that enumerates the enum, so a member declared outside the reserved primitive range fails the build.
 - [ ] `TryGetDecimal` returns the stored value for `MetadataKind.Decimal` without parsing text, and continues to convert from `Int64`, `Double`, and numeric strings.
 - [ ] `TryGetString` returns `false` for a decimal metadata value.
 - [ ] `MetadataValue.ToString()` renders decimals as unquoted invariant-culture numeric text.
@@ -31,9 +32,25 @@ Storing decimals as text also loses type information (a decimal is indistinguish
 
 ### Enum ordering is a hard constraint
 
-`MetadataKindExtensions.IsPrimitive` is implemented as `kind < MetadataKind.Array`. The new member must be inserted as `Decimal = 5` with `Array` and `Object` shifted to `6` and `7`.
+`MetadataKindExtensions.IsPrimitive` is implemented as `kind < MetadataKind.Array`, so membership of the primitive set is decided purely by ordering. Adding `Decimal` after `Object` compiles cleanly and silently classifies decimals as complex values: they would be rejected as CloudEvents extension attributes, rejected inside arrays annotated for header serialization, and would flip `HasOnlyPrimitiveChildren` to `false` on any containing array or object. No compiler diagnostic catches this.
 
-Appending `Decimal = 7` compiles cleanly and silently classifies decimals as complex values: they would be rejected as CloudEvents extension attributes, rejected inside arrays annotated for header serialization, and would flip `HasOnlyPrimitiveChildren` to `false` on any containing array or object. No compiler diagnostic catches this.
+`Decimal` is therefore appended to the primitive block as `5`, and the complex kinds move to a reserved range:
+
+```csharp
+public enum MetadataKind : byte
+{
+    Null = 0, Boolean = 1, Int64 = 2, Double = 3, String = 4, Decimal = 5,
+    // 6-99 are reserved for future primitive kinds
+    Array = 100,
+    Object = 101
+}
+```
+
+The gap exists so that later primitives can be added without renumbering the complex kinds a second time. This is not speculative: CloudEvents defines `Binary`, `URI`, `URI-reference`, and `Timestamp` as attribute types, all of which are currently flattened into `String`. The values are renumbered in this change because `Array` and `Object` move regardless, making the reservation free now and a separate breaking change later. It also settles the numbering before any gRPC mapping can make it wire-visible.
+
+The reserved range must be documented on the enum itself, and `IsPrimitive` must keep the boundary comparison rather than switching to an enumerated list — the comparison is a single instruction on a path used by every array and object construction.
+
+A gap alone does not enforce the invariant. `IsPrimitive` currently has no direct test coverage at all, so the ordering constraint is unguarded. A test must iterate `Enum.GetValues<MetadataKind>()` and assert each member against an explicit expected classification, so that a future member declared on the wrong side of the boundary fails immediately rather than degrading silently.
 
 ### Read side: an explicit non-guarantee
 
@@ -69,7 +86,7 @@ The library is pre-1.0 and breaking changes are permitted, but these are silent 
 
 - `TryGetString` no longer returns `true` for decimals.
 - `Kind` for a decimal is no longer `MetadataKind.String`.
-- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` shift.
+- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` change to `100` and `101`. No code in the solution casts `MetadataKind` to a numeric type and the enum is not exposed by the OpenAPI, Validation, or source-generation packages, so this is invisible today — but any consumer that persisted or transmitted the numeric value is affected.
 - Decimal metadata appears as a JSON number rather than a JSON string in serialized bodies.
 - Decimals differing only in trailing zeros now compare equal.
 

--- a/ai-plans/0052-decimal-metadata-kind.md
+++ b/ai-plans/0052-decimal-metadata-kind.md
@@ -1,0 +1,88 @@
+# Decimal Metadata Kind
+
+## Rationale
+
+`MetadataValue.FromDecimal` converts its input to invariant text and stores `MetadataKind.String`. Decimals therefore serialize into JSON bodies as quoted strings, while `PortableOpenApiSchemaTypeMapper` maps `decimal` to `JsonSchemaType.Number` and `PortableResultsOpenApiDocumentTransformer` emits decimal examples as unquoted numbers. The published contract and the runtime payload disagree. The mismatch is reachable through the built-in validation error definitions, which route every `TypeCode.Decimal` parameter through `FromDecimal`, so any decimal precision-and-scale rule produces a `problem+json` body that violates the OpenAPI document generated for the same endpoint.
+
+Storing decimals as text also loses type information (a decimal is indistinguishable from a numeric-looking string), forces `TryGetDecimal` to run `decimal.TryParse` on every call, and allocates more than necessary. This plan introduces a dedicated `MetadataKind.Decimal` backed by a boxed `decimal`.
+
+## Acceptance Criteria
+
+- [ ] `MetadataValue.FromDecimal` produces a value whose `Kind` is `MetadataKind.Decimal`.
+- [ ] A decimal metadata value is written into JSON bodies as an unquoted JSON number that preserves all significant digits and the original scale.
+- [ ] A `problem+json` body produced by a decimal precision-and-scale validation rule conforms to the OpenAPI document generated for the same endpoint, asserted by an integration test that inspects the raw response body.
+- [ ] `MetadataKind.Decimal` is classified as primitive, so decimals remain valid inside arrays annotated for header serialization and valid as CloudEvents extension attributes.
+- [ ] `TryGetDecimal` returns the stored value for `MetadataKind.Decimal` without parsing text, and continues to convert from `Int64`, `Double`, and numeric strings.
+- [ ] `TryGetString` returns `false` for a decimal metadata value.
+- [ ] `MetadataValue.ToString()` renders decimals as unquoted invariant-culture numeric text.
+- [ ] A decimal metadata value resolves correctly when used as a CloudEvents core string attribute instead of silently becoming `null`.
+- [ ] HTTP header formatting emits decimals without quote characters.
+- [ ] The JSON reader's treatment of numeric tokens is explicitly specified and covered by tests, including the documented cases where a decimal does not read back as `MetadataKind.Decimal`.
+- [ ] `Unsafe.SizeOf<MetadataValue>()` is unchanged from before this plan, asserted by a test that pins the current value.
+- [ ] Test code coverage stays above 95%.
+
+## Technical Details
+
+### Storage
+
+`MetadataKind.Decimal` stores a **boxed** `decimal` in the existing `Reference` slot of `MetadataPayload` at offset 8. An inline 128-bit field would push `Reference` to offset 16 and grow every `MetadataValue` by 8 bytes, including array elements stored inline in `MetadataArrayData` — an unacceptable cost in a library whose primary claim is reduced allocation. Boxing costs 24 bytes on x64, less than the 32–56 bytes the current string representation typically occupies, and removes the parse on every read.
+
+`double` remains the representation for general floating-point numbers. It covers the full JSON numeric range, where `decimal` is limited to ±7.9e28 and could not represent legitimate inbound values such as `1e100`.
+
+### Enum ordering is a hard constraint
+
+`MetadataKindExtensions.IsPrimitive` is implemented as `kind < MetadataKind.Array`. The new member must be inserted as `Decimal = 5` with `Array` and `Object` shifted to `6` and `7`.
+
+Appending `Decimal = 7` compiles cleanly and silently classifies decimals as complex values: they would be rejected as CloudEvents extension attributes, rejected inside arrays annotated for header serialization, and would flip `HasOnlyPrimitiveChildren` to `false` on any containing array or object. No compiler diagnostic catches this.
+
+### Read side: an explicit non-guarantee
+
+A JSON number carries no discriminator between a decimal and a double, so the reader must choose. Two candidate behaviours exist, and the choice must be recorded rather than implied:
+
+- **Default:** `SharedJsonSerialization.Reading.MetadataJsonReader.ReadNumber` keeps its current `Int64`-then-`Double` behaviour and never produces `MetadataKind.Decimal`. `Http.Reading.Json.MetadataJsonReader` delegates to it, so this is a single site.
+- **Opt-in:** a reader option, following the precedent of `HeaderValueParsingMode`, that prefers `Decimal` for numeric tokens outside `Int64` range that fit in `decimal`.
+
+The default is chosen. Preferring `Decimal` unconditionally would make the resulting kind depend on the *magnitude* of the value and would break round-tripping in the opposite direction, with `FromDouble(0.1)` reading back as `Decimal`.
+
+This plan therefore improves **outbound** fidelity. It deliberately does not claim that a decimal round-trips as a decimal; that limitation is inherent to untyped numeric wire formats and is the same constraint recorded for HTTP headers in `0051`. Acceptance criteria must not assert round-trip symmetry for decimals.
+
+### Affected components
+
+Only two exhaustive `MetadataKind` switches exist outside the `Metadata` folder, and both fail to compile without a new branch:
+
+- `SharedJsonSerialization/Writing/MetadataExtensions.WriteMetadataValue` — write via `WriteNumberValue(decimal)`.
+- `CloudEvents/MetadataValueAnnotationHelper`.
+
+The dangerous case is `CloudEventsResultExtensions.GetStringAttribute`, which is an `if`-chain over `TryGetString`/`TryGetBoolean`/`TryGetInt64`/`TryGetDouble` falling through to `null`. Today a decimal is caught by the `TryGetString` branch. After this change it falls through and a decimal-valued `subject`, `type`, or `source` silently becomes `null` instead of resolving or throwing. This is a behavioural regression the compiler will not surface.
+
+Everything else reaches decimals through `IsPrimitive` or the `TryGet*` accessors and needs no change.
+
+### Equality and hashing
+
+`MetadataKind.Decimal` joins the existing `String or Array or Object` group in `GetHashCode`, since a boxed `decimal` hashes correctly through `Reference.GetHashCode()`. `Equals` needs a branch that unboxes and compares as `decimal` rather than comparing references.
+
+This changes observable behaviour: `decimal.Equals` and `decimal.GetHashCode` are scale-insensitive and mutually consistent, so `19.50m` and `19.5m` become equal metadata values. Under the current string storage they compare as `"19.50"` and `"19.5"` and are *not* equal. Scale is still preserved for serialization — only equality changes.
+
+### Breaking changes
+
+The library is pre-1.0 and breaking changes are permitted, but these are silent at compile time for downstream callers and must be listed in the package release notes:
+
+- `TryGetString` no longer returns `true` for decimals.
+- `Kind` for a decimal is no longer `MetadataKind.String`.
+- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` shift.
+- Decimal metadata appears as a JSON number rather than a JSON string in serialized bodies.
+- Decimals differing only in trailing zeros now compare equal.
+
+### Sequencing with #51
+
+This plan should land before `0051-http-header-value-formatting`. That plan's kind table currently folds decimals into the `String` row; landing it first would require amending both the table and its test matrix immediately afterwards. With this plan first, `0051` gains a `Decimal` row from the outset — invariant numeric text, unquoted, identical in shape to the `Double` row.
+
+### Tests
+
+`MetadataValueTests.FromDecimal_ShouldStoreAsString` inverts and must be renamed alongside its assertions. `MetadataObjectTests` and `MetadataValueAnnotationTests` also construct decimal values and need review.
+
+Beyond the unit-level kind matrix, the criterion that carries the actual defect is the OpenAPI conformance test: trigger a decimal precision-and-scale validation failure through an integration test app and assert that the raw `problem+json` body contains an unquoted number for the precision and scale metadata.
+
+### Out of scope
+
+Making decimals round-trip as decimals, and the opt-in reader mode described above. Both are follow-up work once the outbound representation is correct.

--- a/samples/NativeAotMovieRating/packages.lock.json
+++ b/samples/NativeAotMovieRating/packages.lock.json
@@ -142,33 +142,33 @@
       "light.portableresults.aspnetcore.minimalapis": {
         "type": "Project",
         "dependencies": {
-          "Light.PortableResults.AspNetCore.Shared": "[0.6.0, )"
+          "Light.PortableResults.AspNetCore.Shared": "[0.7.0, )"
         }
       },
       "light.portableresults.aspnetcore.openapi": {
         "type": "Project",
         "dependencies": {
-          "Light.PortableResults.AspNetCore.Shared": "[0.6.0, )",
+          "Light.PortableResults.AspNetCore.Shared": "[0.7.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.10, )"
         }
       },
       "light.portableresults.aspnetcore.shared": {
         "type": "Project",
         "dependencies": {
-          "Light.PortableResults": "[0.6.0, )"
+          "Light.PortableResults": "[0.7.0, )"
         }
       },
       "light.portableresults.validation": {
         "type": "Project",
         "dependencies": {
-          "Light.PortableResults": "[0.6.0, )"
+          "Light.PortableResults": "[0.7.0, )"
         }
       },
       "light.portableresults.validation.openapi": {
         "type": "Project",
         "dependencies": {
-          "Light.PortableResults.AspNetCore.OpenApi": "[0.6.0, )",
-          "Light.PortableResults.Validation": "[0.6.0, )"
+          "Light.PortableResults.AspNetCore.OpenApi": "[0.7.0, )",
+          "Light.PortableResults.Validation": "[0.7.0, )"
         }
       },
       "Microsoft.Bcl.HashCode": {
@@ -190,20 +190,20 @@
         "contentHash": "V6crLJ8a29raWeNwxYGfH9RTKA3H0nR0D9LAGzN3KtEsbiiaWkUjDor6OT5Oz7pxCK+NaY2hu2FLoYEOa8oCkA=="
       }
     },
-    "net10.0/linux-x64": {
+    "net10.0/osx-arm64": {
       "Microsoft.DotNet.ILCompiler": {
         "type": "Direct",
         "requested": "[10.0.10, )",
         "resolved": "10.0.10",
         "contentHash": "tnG8ntt/Bk6odvHREnGLMo3PEiihy5iSlIFVp0JbIo00GKtNRt2k73eKZbPqR5yaJNIa3z8R86YLwbxfqpb17g==",
         "dependencies": {
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler": "10.0.10"
+          "runtime.osx-arm64.Microsoft.DotNet.ILCompiler": "10.0.10"
         }
       },
-      "runtime.linux-x64.Microsoft.DotNet.ILCompiler": {
+      "runtime.osx-arm64.Microsoft.DotNet.ILCompiler": {
         "type": "Transitive",
         "resolved": "10.0.10",
-        "contentHash": "WRjSRBfv6A6UjgjO8EQuLe9xqdICpkQx1hACUziCw4B2uGL+2jVhkFLq/G7rxRr3MGvqLo9B+nNdfIJ/5CYN7A=="
+        "contentHash": "cY7edFqVviQMiSvPodJeLZhF6k56grh0QsvcR+2foAUgO0xXsMsVBQiHcZkeiIbhr+SPIklq90OZiJ7JVrc+Dg=="
       }
     }
   }

--- a/src/Light.PortableResults.AspNetCore.MinimalApis/Light.PortableResults.AspNetCore.MinimalApis.csproj
+++ b/src/Light.PortableResults.AspNetCore.MinimalApis/Light.PortableResults.AspNetCore.MinimalApis.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Integration package for turning result instances into Minimal API's IResult instances. Compatible with Native AOT. Compatible with RFC 9457 (and RFC 7807) Problem Details responses.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.MinimalApis 0.6.0
+      Light.PortableResults.AspNetCore.MinimalApis 0.7.0
       ---------------------------------
 
       - LightResult and LightResult&lt;T> and corresponding extension methods to turn result instances into HTTP success responses or RFC 9457 (and RFC 7807) compatible Problem Details responses.

--- a/src/Light.PortableResults.AspNetCore.Mvc/Light.PortableResults.AspNetCore.Mvc.csproj
+++ b/src/Light.PortableResults.AspNetCore.Mvc/Light.PortableResults.AspNetCore.Mvc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Integration package for turning result instances into MVC's IActionResult instances. Compatible with RFC 9457 (and RFC 7807) Problem Details responses.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.MVC 0.6.0
+      Light.PortableResults.AspNetCore.MVC 0.7.0
       ---------------------------------
 
       - LightActionResult and LightActionResult&lt;T> and corresponding extension methods to turn result instances into HTTP success responses or RFC 9457 (and RFC 7807) compatible Problem Details responses.

--- a/src/Light.PortableResults.AspNetCore.OpenApi/Light.PortableResults.AspNetCore.OpenApi.csproj
+++ b/src/Light.PortableResults.AspNetCore.OpenApi/Light.PortableResults.AspNetCore.OpenApi.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Opt-in OpenAPI integration package for Light.PortableResults ASP.NET Core applications. Provides a library-authored schema catalog, endpoint metadata attributes, Minimal API helpers, and a document transformer.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.OpenApi 0.6.0
+      Light.PortableResults.AspNetCore.OpenApi 0.7.0
       -------------------------------------
 
       - Opt-in OpenAPI integration via IServiceCollection.AddPortableResultsOpenApi.

--- a/src/Light.PortableResults.AspNetCore.Shared/Light.PortableResults.AspNetCore.Shared.csproj
+++ b/src/Light.PortableResults.AspNetCore.Shared/Light.PortableResults.AspNetCore.Shared.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>The Light.PortableResults.AspNetCore.Shared package contains shared functionality for writing ASP.NET Core HTTP responses. Compatible with Native AOT. Check out the integration packages Light.PortableResults.AspNetCore.MinimalApis or Light.PortableResults.AspNetCore.Mvc.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.AspNetCore.Shared 0.6.0
+      Light.PortableResults.AspNetCore.Shared 0.7.0
       ---------------------------------
 
       - Result enrichment with ASP.NET Core's HttpContext.

--- a/src/Light.PortableResults.Validation.OpenApi/Light.PortableResults.Validation.OpenApi.csproj
+++ b/src/Light.PortableResults.Validation.OpenApi/Light.PortableResults.Validation.OpenApi.csproj
@@ -4,7 +4,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>OpenAPI bridge package for Light.PortableResults.Validation. Provides built-in validation error metadata contracts and typed helpers for endpoint-specific validation error narrowing.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.Validation.OpenApi 0.6.0
+      Light.PortableResults.Validation.OpenApi 0.7.0
       ----------------------------------------
 
       - Built-in OpenAPI metadata contracts for Light.PortableResults.Validation error codes.

--- a/src/Light.PortableResults.Validation/Light.PortableResults.Validation.csproj
+++ b/src/Light.PortableResults.Validation/Light.PortableResults.Validation.csproj
@@ -4,7 +4,7 @@
     <PublishAot>false</PublishAot>
     <Description>Framework-agnostic validation foundations for Light.PortableResults, including validation contexts, low-allocation checks, validator base classes, and validated value pipelines.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults.Validation 0.6.0
+      Light.PortableResults.Validation 0.7.0
       ---------------------------------
 
       - Validation foundations with validation contexts, checks, validated value pipelines, and sync/async validator base classes.

--- a/src/Light.PortableResults/CloudEvents/MetadataValueAnnotationHelper.cs
+++ b/src/Light.PortableResults/CloudEvents/MetadataValueAnnotationHelper.cs
@@ -39,6 +39,9 @@ public static class MetadataValueAnnotationHelper
             case MetadataKind.String:
                 value.TryGetString(out var stringValue);
                 return MetadataValue.FromString(stringValue, annotation);
+            case MetadataKind.Decimal:
+                value.TryGetDecimal(out var decimalValue);
+                return MetadataValue.FromDecimal(decimalValue, annotation);
             case MetadataKind.Array:
                 value.TryGetArray(out var arrayValue);
                 return MetadataValue.FromArray(WithAnnotation(arrayValue, annotation), annotation);

--- a/src/Light.PortableResults/CloudEvents/Writing/CloudEventsResultExtensions.cs
+++ b/src/Light.PortableResults/CloudEvents/Writing/CloudEventsResultExtensions.cs
@@ -605,8 +605,9 @@ public static class CloudEventsResultExtensions
             return doubleValue.ToString(CultureInfo.InvariantCulture);
         }
 
-        // TryGetDecimal also converts from Int64 and Double, thus the kind is checked explicitly here to keep
-        // this branch independent of the order of the checks above.
+        // TryGetDecimal also converts from Int64, Double, and numeric strings. The checks above are all strict
+        // kind checks and cannot be reached by a decimal, thus the position of this branch does not matter today
+        // - but the kind is checked explicitly so that it cannot swallow those values if it is ever moved up.
         if (metadataValue.Kind == MetadataKind.Decimal && metadataValue.TryGetDecimal(out var decimalValue))
         {
             return decimalValue.ToString(CultureInfo.InvariantCulture);

--- a/src/Light.PortableResults/CloudEvents/Writing/CloudEventsResultExtensions.cs
+++ b/src/Light.PortableResults/CloudEvents/Writing/CloudEventsResultExtensions.cs
@@ -605,6 +605,13 @@ public static class CloudEventsResultExtensions
             return doubleValue.ToString(CultureInfo.InvariantCulture);
         }
 
+        // TryGetDecimal also converts from Int64 and Double, thus the kind is checked explicitly here to keep
+        // this branch independent of the order of the checks above.
+        if (metadataValue.Kind == MetadataKind.Decimal && metadataValue.TryGetDecimal(out var decimalValue))
+        {
+            return decimalValue.ToString(CultureInfo.InvariantCulture);
+        }
+
         return null;
     }
 

--- a/src/Light.PortableResults/Http/Reading/Json/MetadataJsonReader.cs
+++ b/src/Light.PortableResults/Http/Reading/Json/MetadataJsonReader.cs
@@ -4,12 +4,16 @@ using Light.PortableResults.Metadata;
 namespace Light.PortableResults.Http.Reading.Json;
 
 /// <summary>
-/// Provides low-level JSON parsing helpers for metadata values.
+/// Provides low-level JSON parsing helpers for metadata values. All members delegate to
+/// <see cref="SharedJsonSerialization.Reading.MetadataJsonReader" /> - see the remarks there for how
+/// JSON numbers are mapped onto <see cref="MetadataKind" />.
 /// </summary>
 public static class MetadataJsonReader
 {
     /// <summary>
-    /// Reads a <see cref="MetadataValue" /> from the current JSON token.
+    /// Reads a <see cref="MetadataValue" /> from the current JSON token. JSON numbers are read as
+    /// <see cref="MetadataKind.Int64" /> or <see cref="MetadataKind.Double" />, never as
+    /// <see cref="MetadataKind.Decimal" />.
     /// </summary>
     /// <param name="reader">The JSON reader.</param>
     /// <param name="annotation">The annotation applied to parsed values.</param>

--- a/src/Light.PortableResults/Light.PortableResults.csproj
+++ b/src/Light.PortableResults/Light.PortableResults.csproj
@@ -4,7 +4,7 @@
     <PublishAot>false</PublishAot>
     <Description>The Light.PortableResults package implements the core functionality: Results, Errors, Metadata, Functional Extensions, and serialization support for various formats like HTTP and CloudEvents. Compatible with Native AOT. Check out the integration packages Light.PortableResults.AspNetCore.MinimalApis or Light.PortableResults.AspNetCore.Mvc.</Description>
     <PackageReleaseNotes>
-      Light.PortableResults 0.6.0
+      Light.PortableResults 0.7.0
       ---------------------------------
 
       - Contains core functionality: Results, Errors, Metadata, Functional Extensions, and JSON serialization support for HTTP and CloudEvents.

--- a/src/Light.PortableResults/Light.PortableResults.csproj
+++ b/src/Light.PortableResults/Light.PortableResults.csproj
@@ -9,6 +9,19 @@
 
       - Contains core functionality: Results, Errors, Metadata, Functional Extensions, and JSON serialization support for HTTP and CloudEvents.
       - Compatible with .NET Native AOT.
+
+      Breaking changes
+      ---------------------------------
+
+      - Decimal metadata values now have the dedicated kind MetadataKind.Decimal instead of MetadataKind.String,
+        and they are serialized as JSON numbers instead of quoted strings. This aligns the response bodies with
+        the generated OpenAPI documents, which have always described decimals as numbers.
+      - MetadataValue.TryGetString no longer returns true for decimal metadata values. Use TryGetDecimal instead.
+      - Decimal metadata values that differ only in trailing zeros (19.50 and 19.5) now compare equal, because
+        equality is delegated to decimal. The scale is still preserved during serialization.
+      - The numeric values of MetadataKind.Array and MetadataKind.Object changed to 200 and 201 so that the
+        values 6 to 199 are reserved for future primitive kinds. This only affects callers that persisted or
+        transmitted the numeric value of MetadataKind.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Light.PortableResults/Metadata/MetadataKind.cs
+++ b/src/Light.PortableResults/Metadata/MetadataKind.cs
@@ -1,7 +1,17 @@
 namespace Light.PortableResults.Metadata;
 
 /// <summary>
+/// <para>
 /// Discriminates the kind of value stored in a <see cref="MetadataValue" />.
+/// </para>
+/// <para>
+/// The numeric values of the members are a hard constraint:
+/// <see cref="MetadataKindExtensions.IsPrimitive" /> decides membership of the primitive set with a single
+/// comparison against <see cref="Array" />. All primitive kinds must therefore be declared with values below
+/// <see cref="Array" />. The values 6 to 199 are reserved for future primitive kinds (CloudEvents, for example,
+/// defines Binary, URI, URI-reference, and Timestamp attribute types that are currently flattened into
+/// <see cref="String" />), so that adding one of them later does not renumber the complex kinds again.
+/// </para>
 /// </summary>
 public enum MetadataKind : byte
 {
@@ -31,15 +41,23 @@ public enum MetadataKind : byte
     String = 4,
 
     /// <summary>
+    /// The metadata value represents a decimal number with 128 bits. This is considered a primitive value.
+    /// </summary>
+    Decimal = 5,
+
+    // 6 - 199 are reserved for future primitive kinds. Do not declare a primitive kind at 200 or above,
+    // and do not declare a complex kind below 200 - see the remarks on this enum for details.
+
+    /// <summary>
     /// The metadata value represents an array, consisting of other metadata values. This is considered a complex value.
     /// </summary>
-    Array = 5,
+    Array = 200,
 
     /// <summary>
     /// The metadata value represents an object (a key-value store), consisting of other metadata values.
     /// This is considered a complex value.
     /// </summary>
-    Object = 6
+    Object = 201
 }
 
 /// <summary>

--- a/src/Light.PortableResults/Metadata/MetadataPayload.cs
+++ b/src/Light.PortableResults/Metadata/MetadataPayload.cs
@@ -13,7 +13,9 @@ namespace Light.PortableResults.Metadata;
 /// <para>
 /// - <see cref="Reference" /> is at offset 8 to avoid overlapping with the primitives. This separation
 /// is critical: the .NET GC tracks object references, and if Ref overlapped with I64/F64, the GC
-/// could misinterpret a raw integer as a pointer, causing crashes or heap corruption.
+/// could misinterpret a raw integer as a pointer, causing crashes or heap corruption. Besides strings,
+/// arrays, and objects, it also holds boxed decimals - see
+/// <see cref="MetadataValue.FromDecimal" /> for why decimals are not stored inline.
 /// </para>
 /// <para>
 /// Total struct size: 16 bytes (8 for primitives + 8 for reference on 64-bit systems).

--- a/src/Light.PortableResults/Metadata/MetadataValue.cs
+++ b/src/Light.PortableResults/Metadata/MetadataValue.cs
@@ -459,8 +459,12 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
                 StringComparison.Ordinal
             ),
             // decimal.Equals is scale-insensitive, thus 19.50m and 19.5m are equal metadata values,
-            // although the scale is preserved when they are serialized.
-            MetadataKind.Decimal => (decimal) _payload.Reference! == (decimal) other._payload.Reference!,
+            // although the scale is preserved when they are serialized. The reference is matched instead of
+            // being cast so that a payload which does not carry a boxed decimal is unequal like every other
+            // kind that cannot be interpreted, rather than throwing.
+            MetadataKind.Decimal => _payload.Reference is decimal @decimal &&
+                                    other._payload.Reference is decimal otherDecimal &&
+                                    @decimal == otherDecimal,
             MetadataKind.Array => ((MetadataArrayData?) _payload.Reference)?.Equals(
                                       (MetadataArrayData?) other._payload.Reference
                                   ) ??
@@ -528,7 +532,9 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
     /// Returns the string representation of this instance.
     /// </summary>
     /// <returns>The string representation.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the value kind is unknown.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the value kind is unknown or when its payload cannot be interpreted for that kind.
+    /// </exception>
     public override string ToString() =>
         Kind switch
         {
@@ -537,10 +543,13 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
             MetadataKind.Int64 => _payload.Int64.ToString(CultureInfo.InvariantCulture),
             MetadataKind.Double => _payload.Float64.ToString(CultureInfo.InvariantCulture),
             MetadataKind.String => $"\"{_payload.Reference}\"",
-            MetadataKind.Decimal => ((decimal) _payload.Reference!).ToString(CultureInfo.InvariantCulture),
+            // A payload that does not carry a boxed decimal falls through to the arm below instead of throwing
+            // a NullReferenceException or an InvalidCastException, mirroring the other reference-backed kinds.
+            MetadataKind.Decimal when _payload.Reference is decimal @decimal =>
+                @decimal.ToString(CultureInfo.InvariantCulture),
             MetadataKind.Array =>
                 ((MetadataArrayData?) _payload.Reference)?.ToString() ?? MetadataArray.EmptyArrayStringRepresentation,
             MetadataKind.Object => "{...}",
-            _ => throw new InvalidOperationException($"Kind '{Kind}' is unknown")
+            _ => throw new InvalidOperationException($"Kind '{Kind}' is unknown or its payload is invalid")
         };
 }

--- a/src/Light.PortableResults/Metadata/MetadataValue.cs
+++ b/src/Light.PortableResults/Metadata/MetadataValue.cs
@@ -5,7 +5,7 @@ namespace Light.PortableResults.Metadata;
 
 /// <summary>
 /// Represents a JSON-compatible metadata value. This is a discriminated union
-/// that can hold null, boolean, int64, double, string, array, or object values.
+/// that can hold null, boolean, int64, double, string, decimal, array, or object values.
 /// </summary>
 public readonly struct MetadataValue : IEquatable<MetadataValue>
 {
@@ -111,7 +111,14 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
         value is null ? Null : new MetadataValue(MetadataKind.String, new MetadataPayload(value), annotation);
 
     /// <summary>
+    /// <para>
     /// Creates a <see cref="MetadataValue" /> from a decimal value.
+    /// </para>
+    /// <para>
+    /// The decimal is boxed and stored in the reference slot of the payload. Storing it inline would push the
+    /// reference slot to offset 16 and grow every <see cref="MetadataValue" /> - including the ones stored inline
+    /// in arrays and objects - by 8 bytes.
+    /// </para>
     /// </summary>
     /// <param name="value">The decimal value.</param>
     /// <param name="annotation">The serialization annotation.</param>
@@ -119,11 +126,8 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
     public static MetadataValue FromDecimal(
         decimal value,
         MetadataValueAnnotation annotation = DefaultAnnotation
-    )
-    {
-        var @string = value.ToString(CultureInfo.InvariantCulture);
-        return new MetadataValue(MetadataKind.String, new MetadataPayload(@string), annotation);
-    }
+    ) =>
+        new (MetadataKind.Decimal, new MetadataPayload((object) value), annotation);
 
     /// <summary>
     /// Creates a <see cref="MetadataValue" /> from a <see cref="MetadataArray" />.
@@ -347,7 +351,8 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
     }
 
     /// <summary>
-    /// Attempts to get a decimal value.
+    /// Attempts to get a decimal value. Besides <see cref="MetadataKind.Decimal" />, this method also converts
+    /// from <see cref="MetadataKind.Int64" />, <see cref="MetadataKind.Double" />, and numeric strings.
     /// </summary>
     /// <param name="value">When this method returns, contains the decimal value if present.</param>
     /// <returns><see langword="true" /> if the value can be represented as a decimal; otherwise, <see langword="false" />.</returns>
@@ -355,6 +360,9 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
     {
         switch (Kind)
         {
+            case MetadataKind.Decimal when _payload.Reference is decimal @decimal:
+                value = @decimal;
+                return true;
             case MetadataKind.String when _payload.Reference is string @string:
                 return decimal.TryParse(@string, NumberStyles.Number, CultureInfo.InvariantCulture, out value);
             case MetadataKind.Double:
@@ -450,6 +458,9 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
                 (string?) other._payload.Reference,
                 StringComparison.Ordinal
             ),
+            // decimal.Equals is scale-insensitive, thus 19.50m and 19.5m are equal metadata values,
+            // although the scale is preserved when they are serialized.
+            MetadataKind.Decimal => (decimal) _payload.Reference! == (decimal) other._payload.Reference!,
             MetadataKind.Array => ((MetadataArrayData?) _payload.Reference)?.Equals(
                                       (MetadataArrayData?) other._payload.Reference
                                   ) ??
@@ -487,7 +498,9 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
             case MetadataKind.Double:
                 hashCodeBuilder.Add(_payload.Float64);
                 break;
-            case MetadataKind.String or MetadataKind.Array or MetadataKind.Object:
+            // decimal.GetHashCode is scale-insensitive and consistent with decimal.Equals, thus boxed decimals
+            // can be hashed through the reference like the other reference-backed kinds.
+            case MetadataKind.String or MetadataKind.Decimal or MetadataKind.Array or MetadataKind.Object:
                 hashCodeBuilder.Add(_payload.Reference?.GetHashCode() ?? 0);
                 break;
         }
@@ -524,6 +537,7 @@ public readonly struct MetadataValue : IEquatable<MetadataValue>
             MetadataKind.Int64 => _payload.Int64.ToString(CultureInfo.InvariantCulture),
             MetadataKind.Double => _payload.Float64.ToString(CultureInfo.InvariantCulture),
             MetadataKind.String => $"\"{_payload.Reference}\"",
+            MetadataKind.Decimal => ((decimal) _payload.Reference!).ToString(CultureInfo.InvariantCulture),
             MetadataKind.Array =>
                 ((MetadataArrayData?) _payload.Reference)?.ToString() ?? MetadataArray.EmptyArrayStringRepresentation,
             MetadataKind.Object => "{...}",

--- a/src/Light.PortableResults/SharedJsonSerialization/Reading/MetadataJsonReader.cs
+++ b/src/Light.PortableResults/SharedJsonSerialization/Reading/MetadataJsonReader.cs
@@ -4,12 +4,26 @@ using Light.PortableResults.Metadata;
 namespace Light.PortableResults.SharedJsonSerialization.Reading;
 
 /// <summary>
+/// <para>
 /// Provides low-level JSON parsing helpers for metadata values.
+/// </para>
+/// <para>
+/// A JSON number carries no discriminator that would tell a decimal from a double, thus the reader
+/// never produces <see cref="MetadataKind.Decimal" />: numbers that fit into a 64-bit integer become
+/// <see cref="MetadataKind.Int64" />, all others become <see cref="MetadataKind.Double" />. Decimals
+/// consequently do not round-trip as decimals - a value written with
+/// <see cref="MetadataValue.FromDecimal" /> reads back as <see cref="MetadataKind.Int64" /> or
+/// <see cref="MetadataKind.Double" />. This is deliberate: preferring decimals would make the resulting
+/// kind depend on the magnitude of the value and would break round-tripping in the opposite direction,
+/// where <see cref="MetadataValue.FromDouble" /> would read back as a decimal.
+/// </para>
 /// </summary>
 public static class MetadataJsonReader
 {
     /// <summary>
-    /// Reads a <see cref="MetadataValue" /> from the current JSON token.
+    /// Reads a <see cref="MetadataValue" /> from the current JSON token. JSON numbers are read as
+    /// <see cref="MetadataKind.Int64" /> or <see cref="MetadataKind.Double" />, never as
+    /// <see cref="MetadataKind.Decimal" /> - see the remarks on <see cref="MetadataJsonReader" />.
     /// </summary>
     /// <param name="reader">The JSON reader.</param>
     /// <param name="annotation">The annotation applied to parsed values.</param>

--- a/src/Light.PortableResults/SharedJsonSerialization/Writing/MetadataExtensions.cs
+++ b/src/Light.PortableResults/SharedJsonSerialization/Writing/MetadataExtensions.cs
@@ -74,6 +74,10 @@ public static class MetadataExtensions
                 value.TryGetString(out var stringMetadataValue);
                 writer.WriteStringValue(stringMetadataValue);
                 break;
+            case MetadataKind.Decimal:
+                value.TryGetDecimal(out var decimalMetadataValue);
+                writer.WriteNumberValue(decimalMetadataValue);
+                break;
             case MetadataKind.Array:
                 value.TryGetArray(out var arrayMetadataValue);
                 writer.WriteMetadataArray(arrayMetadataValue, requiredAnnotation);

--- a/tests/Light.PortableResults.Tests/CloudEvents/MetadataValueAnnotationHelperTests.cs
+++ b/tests/Light.PortableResults.Tests/CloudEvents/MetadataValueAnnotationHelperTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Reflection;
 using FluentAssertions;
 using Light.PortableResults.CloudEvents;
 using Light.PortableResults.Metadata;
+using Light.PortableResults.Tests.Metadata;
 using Xunit;
 
 namespace Light.PortableResults.Tests.CloudEvents;
@@ -74,6 +74,21 @@ public sealed class MetadataValueAnnotationHelperTests
     }
 
     [Fact]
+    public void WithAnnotation_ShouldRewriteDecimalValue()
+    {
+        var rewritten = MetadataValueAnnotationHelper.WithAnnotation(
+            MetadataValue.FromDecimal(19.50m, MetadataValueAnnotation.SerializeInHttpResponseBody),
+            MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes
+        );
+
+        rewritten.Kind.Should().Be(MetadataKind.Decimal);
+        rewritten.TryGetDecimal(out var value).Should().BeTrue();
+        value.Should().Be(19.50m);
+        rewritten.ToString().Should().Be("19.50");
+        rewritten.Annotation.Should().Be(MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes);
+    }
+
+    [Fact]
     public void WithAnnotation_ShouldRewriteNestedArrayAndObjectValues()
     {
         var nestedObject = MetadataObject.Create(("inner", MetadataValue.FromString("value")));
@@ -138,7 +153,7 @@ public sealed class MetadataValueAnnotationHelperTests
     [Fact]
     public void WithAnnotation_WithUnsupportedMetadataKind_ShouldThrowArgumentOutOfRangeException()
     {
-        var invalidValue = CreateMetadataValueWithInvalidKind();
+        var invalidValue = MetadataValueTestFactory.CreateWithUndeclaredKind();
 
         var act = () => MetadataValueAnnotationHelper.WithAnnotation(
             invalidValue,
@@ -149,25 +164,4 @@ public sealed class MetadataValueAnnotationHelperTests
            .Which.ParamName.Should().Be("value");
     }
 
-    private static MetadataValue CreateMetadataValueWithInvalidKind()
-    {
-        var metadataValueType = typeof(MetadataValue);
-        var metadataPayloadType = metadataValueType.Assembly.GetType(
-            "Light.PortableResults.Metadata.MetadataPayload",
-            throwOnError: true
-        )!;
-
-        var constructor = metadataValueType.GetConstructor(
-            BindingFlags.Instance | BindingFlags.NonPublic,
-            binder: null,
-            [typeof(MetadataKind), metadataPayloadType, typeof(MetadataValueAnnotation)],
-            modifiers: null
-        )!;
-
-        var payload = Activator.CreateInstance(metadataPayloadType)!;
-
-        return (MetadataValue) constructor.Invoke(
-            [(MetadataKind) byte.MaxValue, payload, MetadataValue.DefaultAnnotation]
-        );
-    }
 }

--- a/tests/Light.PortableResults.Tests/CloudEvents/Writing/CloudEventsResultExtensionsTests.cs
+++ b/tests/Light.PortableResults.Tests/CloudEvents/Writing/CloudEventsResultExtensionsTests.cs
@@ -385,6 +385,63 @@ public sealed class CloudEventsResultExtensionsTests
     }
 
     [Fact]
+    public void ToCloudEvent_ShouldResolveCoreStringAttributes_FromDecimalMetadataValues()
+    {
+        var metadata = MetadataObject.Create(
+            (
+                "type",
+                MetadataValue.FromString(
+                    "app.success",
+                    MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes
+                )
+            ),
+            (
+                "source",
+                MetadataValue.FromString(
+                    "urn:test:source",
+                    MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes
+                )
+            ),
+            (
+                "subject",
+                MetadataValue.FromDecimal(19.50m, MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes)
+            )
+        );
+        var result = Result.Ok(metadata);
+
+        var json = result.ToCloudEvent(options: CreateWriteOptions(source: null));
+
+        using var document = JsonDocument.Parse(json);
+
+        document.RootElement.GetProperty("subject").GetString().Should().Be("19.50");
+    }
+
+    [Fact]
+    public void ToCloudEvent_ShouldWriteDecimalExtensionAttribute_AsUnquotedNumber()
+    {
+        var metadata = MetadataObject.Create(
+            (
+                "price",
+                MetadataValue.FromDecimal(19.99m, MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes)
+            )
+        );
+        var result = Result.Ok(metadata);
+
+        var json = result.ToCloudEvent(
+            successType: "app.success",
+            failureType: "app.failure",
+            id: "evt-decimal",
+            options: CreateWriteOptions()
+        );
+
+        using var document = JsonDocument.Parse(json);
+        var price = document.RootElement.GetProperty("price");
+
+        price.ValueKind.Should().Be(JsonValueKind.Number);
+        price.GetDecimal().Should().Be(19.99m);
+    }
+
+    [Fact]
     public void ToCloudEvent_ShouldResolveTimeFromMetadata_WhenProvidedAsExtensionAttribute()
     {
         var expectedTime = new DateTimeOffset(2026, 2, 14, 18, 45, 0, TimeSpan.Zero);

--- a/tests/Light.PortableResults.Tests/Http/Reading/Json/MetadataJsonReaderTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/Reading/Json/MetadataJsonReaderTests.cs
@@ -149,6 +149,47 @@ public sealed class MetadataJsonReaderTests
         boolValue.Should().BeFalse();
     }
 
+    // A JSON number carries no discriminator between a decimal and a double, thus the reader deliberately never
+    // produces MetadataKind.Decimal. These tests pin that non-guarantee - decimals do not round-trip as decimals.
+    [Theory]
+    [InlineData("42", MetadataKind.Int64)]
+    [InlineData("-9223372036854775808", MetadataKind.Int64)]
+    [InlineData("3.5", MetadataKind.Double)]
+    [InlineData("19.99", MetadataKind.Double)]
+    [InlineData("1e100", MetadataKind.Double)]
+    public void ReadMetadataValue_ShouldNeverProduceDecimalKind(string json, MetadataKind expectedKind)
+    {
+        var reader = CreateReader(json);
+
+        var value = MetadataJsonReader.ReadMetadataValue(ref reader);
+
+        value.Kind.Should().Be(expectedKind);
+    }
+
+    [Fact]
+    public void ReadMetadataValue_ShouldReadWrittenDecimalAsDouble()
+    {
+        var reader = CreateReader(MetadataValue.FromDecimal(19.99m).ToString());
+
+        var value = MetadataJsonReader.ReadMetadataValue(ref reader);
+
+        value.Kind.Should().Be(MetadataKind.Double);
+        value.TryGetDecimal(out var decimalValue).Should().BeTrue();
+        decimalValue.Should().Be(19.99m);
+    }
+
+    [Fact]
+    public void ReadMetadataValue_ShouldReadWrittenIntegralDecimalAsInt64()
+    {
+        var reader = CreateReader(MetadataValue.FromDecimal(20m).ToString());
+
+        var value = MetadataJsonReader.ReadMetadataValue(ref reader);
+
+        value.Kind.Should().Be(MetadataKind.Int64);
+        value.TryGetDecimal(out var decimalValue).Should().BeTrue();
+        decimalValue.Should().Be(20m);
+    }
+
     [Fact]
     public void ReadMetadataValue_ShouldThrow_OnUnsupportedToken()
     {

--- a/tests/Light.PortableResults.Tests/Http/Writing/Headers/DefaultHttpHeaderConversionServiceTests.cs
+++ b/tests/Light.PortableResults.Tests/Http/Writing/Headers/DefaultHttpHeaderConversionServiceTests.cs
@@ -50,6 +50,20 @@ public sealed class DefaultHttpHeaderConversionServiceTests
         header.Value.ToString().Should().Be("42");
     }
 
+    [Fact]
+    public void PrepareHttpHeader_ShouldFormatDecimalWithoutQuotes()
+    {
+        var service = new DefaultHttpHeaderConversionService(
+            new Dictionary<string, HttpHeaderConverter>().ToFrozenDictionary()
+        );
+
+        var header = service.PrepareHttpHeader("price", MetadataValue.FromDecimal(19.50m));
+
+        header.Key.Should().Be("price");
+        header.Value.ToString().Should().Be("19.50");
+        header.Value.ToString().Should().NotContain("\"");
+    }
+
     private sealed class TraceIdConverter : HttpHeaderConverter
     {
         public TraceIdConverter() : base(["traceId"]) { }

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataKindTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataKindTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Light.PortableResults.Metadata;
+using Xunit;
+
+namespace Light.PortableResults.Tests.Metadata;
+
+public sealed class MetadataKindTests
+{
+    // MetadataKindExtensions.IsPrimitive decides membership of the primitive set purely by ordering
+    // (kind < MetadataKind.Array). A new member declared on the wrong side of that boundary compiles cleanly
+    // and silently changes behavior, thus every declared member is pinned to its expected classification here.
+    private static readonly Dictionary<MetadataKind, bool> ExpectedClassifications = new ()
+    {
+        [MetadataKind.Null] = true,
+        [MetadataKind.Boolean] = true,
+        [MetadataKind.Int64] = true,
+        [MetadataKind.Double] = true,
+        [MetadataKind.String] = true,
+        [MetadataKind.Decimal] = true,
+        [MetadataKind.Array] = false,
+        [MetadataKind.Object] = false
+    };
+
+    [Fact]
+    public void EveryDeclaredKindShouldHaveAnExpectedClassification()
+    {
+        Enum.GetValues<MetadataKind>().Should().BeEquivalentTo(ExpectedClassifications.Keys);
+    }
+
+    [Fact]
+    public void EveryDeclaredKindShouldBeClassifiedCorrectly()
+    {
+        foreach (var kind in Enum.GetValues<MetadataKind>())
+        {
+            ExpectedClassifications.Should().ContainKey(kind);
+            kind.IsPrimitive()
+               .Should()
+               .Be(
+                    ExpectedClassifications[kind],
+                    "the classification of '{0}' must not change silently",
+                    kind
+                );
+        }
+    }
+
+    // The reserved range only pays off if no primitive kind is declared at 200 or above and no complex kind
+    // below 200 - the gap itself cannot enforce that.
+    [Fact]
+    public void PrimitiveKindsShouldStayWithinTheReservedRange()
+    {
+        var primitiveKinds = Enum.GetValues<MetadataKind>().Where(static kind => kind.IsPrimitive());
+
+        primitiveKinds.Should().OnlyContain(kind => (byte) kind < 200);
+    }
+
+    [Fact]
+    public void ComplexKindsShouldStartAtTheReservedBoundary()
+    {
+        var complexKinds = Enum.GetValues<MetadataKind>().Where(static kind => !kind.IsPrimitive());
+
+        complexKinds.Should().OnlyContain(kind => (byte) kind >= 200);
+    }
+}

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataKindTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataKindTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Light.PortableResults.Metadata;
 using Xunit;
@@ -11,23 +10,41 @@ public sealed class MetadataKindTests
 {
     // MetadataKindExtensions.IsPrimitive decides membership of the primitive set purely by ordering
     // (kind < MetadataKind.Array). A new member declared on the wrong side of that boundary compiles cleanly
-    // and silently changes behavior, thus every declared member is pinned to its expected classification here.
-    private static readonly Dictionary<MetadataKind, bool> ExpectedClassifications = new ()
+    // and silently changes behavior, thus every declared member is pinned here - both its numeric value, which
+    // keeps the range 6 - 199 reserved for future primitive kinds and is visible to callers that persisted or
+    // transmitted it, and its classification.
+    private static readonly Dictionary<MetadataKind, (byte Value, bool IsPrimitive)> ExpectedMembers = new ()
     {
-        [MetadataKind.Null] = true,
-        [MetadataKind.Boolean] = true,
-        [MetadataKind.Int64] = true,
-        [MetadataKind.Double] = true,
-        [MetadataKind.String] = true,
-        [MetadataKind.Decimal] = true,
-        [MetadataKind.Array] = false,
-        [MetadataKind.Object] = false
+        [MetadataKind.Null] = (0, true),
+        [MetadataKind.Boolean] = (1, true),
+        [MetadataKind.Int64] = (2, true),
+        [MetadataKind.Double] = (3, true),
+        [MetadataKind.String] = (4, true),
+        [MetadataKind.Decimal] = (5, true),
+        [MetadataKind.Array] = (200, false),
+        [MetadataKind.Object] = (201, false)
     };
 
     [Fact]
-    public void EveryDeclaredKindShouldHaveAnExpectedClassification()
+    public void EveryDeclaredKindShouldBePinned()
     {
-        Enum.GetValues<MetadataKind>().Should().BeEquivalentTo(ExpectedClassifications.Keys);
+        Enum.GetValues<MetadataKind>().Should().BeEquivalentTo(ExpectedMembers.Keys);
+    }
+
+    [Fact]
+    public void EveryDeclaredKindShouldKeepItsNumericValue()
+    {
+        foreach (var kind in Enum.GetValues<MetadataKind>())
+        {
+            ExpectedMembers.Should().ContainKey(kind);
+            ((byte) kind)
+               .Should()
+               .Be(
+                    ExpectedMembers[kind].Value,
+                    "the numeric value of '{0}' must not change silently",
+                    kind
+                );
+        }
     }
 
     [Fact]
@@ -35,32 +52,14 @@ public sealed class MetadataKindTests
     {
         foreach (var kind in Enum.GetValues<MetadataKind>())
         {
-            ExpectedClassifications.Should().ContainKey(kind);
+            ExpectedMembers.Should().ContainKey(kind);
             kind.IsPrimitive()
                .Should()
                .Be(
-                    ExpectedClassifications[kind],
+                    ExpectedMembers[kind].IsPrimitive,
                     "the classification of '{0}' must not change silently",
                     kind
                 );
         }
-    }
-
-    // The reserved range only pays off if no primitive kind is declared at 200 or above and no complex kind
-    // below 200 - the gap itself cannot enforce that.
-    [Fact]
-    public void PrimitiveKindsShouldStayWithinTheReservedRange()
-    {
-        var primitiveKinds = Enum.GetValues<MetadataKind>().Where(static kind => kind.IsPrimitive());
-
-        primitiveKinds.Should().OnlyContain(kind => (byte) kind < 200);
-    }
-
-    [Fact]
-    public void ComplexKindsShouldStartAtTheReservedBoundary()
-    {
-        var complexKinds = Enum.GetValues<MetadataKind>().Where(static kind => !kind.IsPrimitive());
-
-        complexKinds.Should().OnlyContain(kind => (byte) kind >= 200);
     }
 }

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataObjectTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataObjectTests.cs
@@ -104,12 +104,53 @@ public sealed class MetadataObjectTests
     }
 
     [Fact]
-    public void TryGetDecimal_ShouldParseDecimalString()
+    public void TryGetDecimal_ShouldReturnStoredDecimal()
     {
         var obj = MetadataObject.Create(("price", MetadataValue.FromDecimal(19.99m)));
 
+        obj.TryGetValue("price", out var value).Should().BeTrue();
+        value.Kind.Should().Be(MetadataKind.Decimal);
         obj.TryGetDecimal("price", out var price).Should().BeTrue();
         price.Should().Be(19.99m);
+    }
+
+    [Fact]
+    public void TryGetString_ShouldReturnFalse_ForDecimal()
+    {
+        var obj = MetadataObject.Create(("price", MetadataValue.FromDecimal(19.99m)));
+
+        obj.TryGetString("price", out var price).Should().BeFalse();
+        price.Should().BeNull();
+    }
+
+    // Equals and GetHashCode fail silently for a kind they do not handle, thus decimals are exercised through
+    // object equality and a dictionary lookup here.
+    [Fact]
+    public void ObjectsWithEqualDecimals_ShouldBeEqualAndHashAlike()
+    {
+        var first = MetadataObject.Create(("price", MetadataValue.FromDecimal(19.99m)));
+        var second = MetadataObject.Create(("price", MetadataValue.FromDecimal(19.99m)));
+
+        first.Equals(second).Should().BeTrue();
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Fact]
+    public void ObjectsWithDifferentDecimals_ShouldNotBeEqual()
+    {
+        var first = MetadataObject.Create(("price", MetadataValue.FromDecimal(19.99m)));
+        var second = MetadataObject.Create(("price", MetadataValue.FromDecimal(24.99m)));
+
+        first.Equals(second).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DecimalMetadataValue_ShouldBeUsableAsDictionaryKey()
+    {
+        var dictionary = new Dictionary<MetadataValue, string> { [MetadataValue.FromDecimal(19.99m)] = "price" };
+
+        dictionary.TryGetValue(MetadataValue.FromDecimal(19.99m), out var target).Should().BeTrue();
+        target.Should().Be("price");
     }
 
     [Fact]

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataValueTestFactory.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataValueTestFactory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using Light.PortableResults.Metadata;
+
+namespace Light.PortableResults.Tests.Metadata;
+
+/// <summary>
+/// Creates metadata values that carry a <see cref="MetadataKind" /> which is not declared on the enum. No dispatch
+/// site on <see cref="MetadataKind" /> fails to compile when a new kind is added, thus the fallback arms are the
+/// only safety net left and they have to be pinned by tests.
+/// </summary>
+internal static class MetadataValueTestFactory
+{
+    public static MetadataValue CreateWithUndeclaredKind(MetadataKind kind = (MetadataKind) byte.MaxValue)
+    {
+        var metadataValueType = typeof(MetadataValue);
+        var metadataPayloadType = metadataValueType.Assembly.GetType(
+            "Light.PortableResults.Metadata.MetadataPayload",
+            throwOnError: true
+        )!;
+
+        var constructor = metadataValueType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(MetadataKind), metadataPayloadType, typeof(MetadataValueAnnotation)],
+            modifiers: null
+        )!;
+
+        var payload = Activator.CreateInstance(metadataPayloadType)!;
+
+        return (MetadataValue) constructor.Invoke([kind, payload, MetadataValue.DefaultAnnotation]);
+    }
+}

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataValueTestFactory.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataValueTestFactory.cs
@@ -5,13 +5,17 @@ using Light.PortableResults.Metadata;
 namespace Light.PortableResults.Tests.Metadata;
 
 /// <summary>
-/// Creates metadata values that carry a <see cref="MetadataKind" /> which is not declared on the enum. No dispatch
-/// site on <see cref="MetadataKind" /> fails to compile when a new kind is added, thus the fallback arms are the
-/// only safety net left and they have to be pinned by tests.
+/// Creates metadata values whose kind and payload do not match what the factory methods on
+/// <see cref="MetadataValue" /> produce - a kind that is not declared on the enum, or a declared kind whose payload
+/// is empty. No dispatch site on <see cref="MetadataKind" /> fails to compile when a new kind is added, thus the
+/// fallback arms are the only safety net left and they have to be pinned by tests.
 /// </summary>
 internal static class MetadataValueTestFactory
 {
-    public static MetadataValue CreateWithUndeclaredKind(MetadataKind kind = (MetadataKind) byte.MaxValue)
+    public static MetadataValue CreateWithUndeclaredKind(MetadataKind kind = (MetadataKind) byte.MaxValue) =>
+        CreateWithEmptyPayload(kind);
+
+    public static MetadataValue CreateWithEmptyPayload(MetadataKind kind)
     {
         var metadataValueType = typeof(MetadataValue);
         var metadataPayloadType = metadataValueType.Assembly.GetType(

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataValueTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataValueTests.cs
@@ -626,6 +626,30 @@ public sealed class MetadataValueTests
         decimalValue.Equals(doubleValue).Should().BeFalse();
     }
 
+    // FromDecimal is the only way to create a decimal value, thus a decimal kind without a boxed decimal in the
+    // payload is unreachable through the public API. Equals and ToString still handle it, because the dispatch
+    // sites are the last safety net for a kind that is only half-implemented.
+    [Fact]
+    public void Equals_Decimal_ShouldReturnFalse_ForEmptyPayload()
+    {
+        var wellFormed = MetadataValue.FromDecimal(19.99m);
+        var malformed = MetadataValueTestFactory.CreateWithEmptyPayload(MetadataKind.Decimal);
+
+        wellFormed.Equals(malformed).Should().BeFalse();
+        malformed.Equals(wellFormed).Should().BeFalse();
+        malformed.Equals(malformed).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToString_Decimal_ShouldThrow_ForEmptyPayload()
+    {
+        var malformed = MetadataValueTestFactory.CreateWithEmptyPayload(MetadataKind.Decimal);
+
+        var act = () => malformed.ToString();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
     [Fact]
     public void GetHashCode_Decimal_ShouldReturnConsistentValue()
     {
@@ -667,9 +691,15 @@ public sealed class MetadataValueTests
     // Decimals are stored boxed in the reference slot of the payload precisely so that MetadataValue does not
     // grow: array and object elements are stored inline, thus every additional byte multiplies. This test pins
     // the size to the value it had before MetadataKind.Decimal was introduced.
+    //
+    // The pinned value describes a 64-bit process: the payload holds 8 bytes of primitives plus a pointer-sized
+    // reference slot. On a 32-bit runtime the reference slot shrinks and the expected value is a different one,
+    // so the bitness is asserted first - a failure there means the pin needs a second case, not a new number.
     [Fact]
     public void MetadataValue_ShouldNotExceedItsPinnedSize()
     {
+        Environment.Is64BitProcess.Should().BeTrue("the pinned size describes a 64-bit process");
+
         Unsafe.SizeOf<MetadataValue>().Should().Be(24);
     }
 }

--- a/tests/Light.PortableResults.Tests/Metadata/MetadataValueTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/MetadataValueTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Light.PortableResults.Metadata;
 using Xunit;
@@ -103,23 +105,59 @@ public sealed class MetadataValueTests
     }
 
     [Fact]
-    public void FromDecimal_ShouldStoreAsString()
+    public void FromDecimal_ShouldStoreAsDecimal()
     {
         var input = 123.456m;
         var value = MetadataValue.FromDecimal(input);
 
-        value.Kind.Should().Be(MetadataKind.String);
-        value.TryGetString(out var str).Should().BeTrue();
-        str.Should().Be("123.456");
+        value.Kind.Should().Be(MetadataKind.Decimal);
+        value.TryGetDecimal(out var result).Should().BeTrue();
+        result.Should().Be(input);
     }
 
     [Fact]
-    public void TryGetDecimal_ShouldParseDecimalString()
+    public void FromDecimal_ShouldPreserveScale()
+    {
+        var value = MetadataValue.FromDecimal(19.50m);
+
+        value.TryGetDecimal(out var result).Should().BeTrue();
+        result.ToString(CultureInfo.InvariantCulture).Should().Be("19.50");
+    }
+
+    [Fact]
+    public void TryGetString_ShouldReturnFalse_ForDecimal()
+    {
+        var value = MetadataValue.FromDecimal(99.99m);
+
+        value.TryGetString(out var result).Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetDecimal_ShouldReturnStoredValue()
     {
         var value = MetadataValue.FromDecimal(99.99m);
 
         value.TryGetDecimal(out var result).Should().BeTrue();
         result.Should().Be(99.99m);
+    }
+
+    [Fact]
+    public void TryGetDecimal_ShouldParseNumericString()
+    {
+        var value = MetadataValue.FromString("99.99");
+
+        value.TryGetDecimal(out var result).Should().BeTrue();
+        result.Should().Be(99.99m);
+    }
+
+    [Fact]
+    public void TryGetDecimal_ShouldReturnFalse_ForNonNumericString()
+    {
+        var value = MetadataValue.FromString("not a number");
+
+        value.TryGetDecimal(out var result).Should().BeFalse();
+        result.Should().Be(0m);
     }
 
     [Fact]
@@ -195,9 +233,9 @@ public sealed class MetadataValueTests
     {
         MetadataValue value = 123.456m;
 
-        value.Kind.Should().Be(MetadataKind.String);
-        value.TryGetString(out var result).Should().BeTrue();
-        result.Should().Be("123.456");
+        value.Kind.Should().Be(MetadataKind.Decimal);
+        value.TryGetDecimal(out var result).Should().BeTrue();
+        result.Should().Be(123.456m);
     }
 
     [Fact]
@@ -556,5 +594,82 @@ public sealed class MetadataValueTests
 
         value1.Equals(value2).Should().BeTrue();
         value1.Equals(value3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Decimals_ShouldCompareByValue()
+    {
+        var value1 = MetadataValue.FromDecimal(19.99m);
+        var value2 = MetadataValue.FromDecimal(19.99m);
+        var value3 = MetadataValue.FromDecimal(24.99m);
+
+        value1.Equals(value2).Should().BeTrue();
+        value1.Equals(value3).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_Decimals_ShouldIgnoreScale()
+    {
+        var value1 = MetadataValue.FromDecimal(19.50m);
+        var value2 = MetadataValue.FromDecimal(19.5m);
+
+        value1.Equals(value2).Should().BeTrue();
+        value1.GetHashCode().Should().Be(value2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_DecimalAndDouble_ShouldNotBeEqual()
+    {
+        var decimalValue = MetadataValue.FromDecimal(19.5m);
+        var doubleValue = MetadataValue.FromDouble(19.5);
+
+        decimalValue.Equals(doubleValue).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_Decimal_ShouldReturnConsistentValue()
+    {
+        var value1 = MetadataValue.FromDecimal(19.99m);
+        var value2 = MetadataValue.FromDecimal(19.99m);
+
+        value1.GetHashCode().Should().Be(value2.GetHashCode());
+    }
+
+    [Fact]
+    public void ToString_Decimal_ShouldReturnUnquotedNumber()
+    {
+        var value = MetadataValue.FromDecimal(19.50m);
+
+        value.ToString().Should().Be("19.50");
+    }
+
+    [Fact]
+    public void ToString_Decimal_ShouldUseInvariantCulture()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        try
+        {
+            MetadataValue.FromDecimal(1234.56m).ToString().Should().Be("1234.56");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    [Fact]
+    public void Decimal_ShouldBeClassifiedAsPrimitive()
+    {
+        MetadataKind.Decimal.IsPrimitive().Should().BeTrue();
+    }
+
+    // Decimals are stored boxed in the reference slot of the payload precisely so that MetadataValue does not
+    // grow: array and object elements are stored inline, thus every additional byte multiplies. This test pins
+    // the size to the value it had before MetadataKind.Decimal was introduced.
+    [Fact]
+    public void MetadataValue_ShouldNotExceedItsPinnedSize()
+    {
+        Unsafe.SizeOf<MetadataValue>().Should().Be(24);
     }
 }

--- a/tests/Light.PortableResults.Tests/Metadata/UndeclaredMetadataKindFallbackTests.cs
+++ b/tests/Light.PortableResults.Tests/Metadata/UndeclaredMetadataKindFallbackTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Light.PortableResults.Metadata;
+using Light.PortableResults.SharedJsonSerialization.Writing;
+using Xunit;
+
+namespace Light.PortableResults.Tests.Metadata;
+
+// Every site that dispatches on MetadataKind has a fallback arm, thus adding a kind and forgetting a site breaks
+// nothing at compile time. These tests pin what the fallback arms do so that the blast radius of a half-finished
+// kind is at least documented.
+public sealed class UndeclaredMetadataKindFallbackTests
+{
+    [Fact]
+    public void Equals_ShouldReturnFalse_ForUndeclaredKind()
+    {
+        var first = MetadataValueTestFactory.CreateWithUndeclaredKind();
+        var second = MetadataValueTestFactory.CreateWithUndeclaredKind();
+
+        first.Equals(second).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldOnlyHashTheKind_ForUndeclaredKind()
+    {
+        var first = MetadataValueTestFactory.CreateWithUndeclaredKind();
+        var second = MetadataValueTestFactory.CreateWithUndeclaredKind((MetadataKind) (byte.MaxValue - 1));
+
+        first.GetHashCode().Should().NotBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void ToString_ShouldThrow_ForUndeclaredKind()
+    {
+        var value = MetadataValueTestFactory.CreateWithUndeclaredKind();
+
+        var act = () => value.ToString();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*is unknown*");
+    }
+
+    [Fact]
+    public void WriteMetadataValue_ShouldWriteNull_ForUndeclaredKind()
+    {
+        var value = MetadataValueTestFactory.CreateWithUndeclaredKind();
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteMetadataValue(value, MetadataValueAnnotation.SerializeInHttpResponseBody);
+            writer.Flush();
+        }
+
+        Encoding.UTF8.GetString(stream.ToArray()).Should().Be("null");
+    }
+}

--- a/tests/Light.PortableResults.Tests/MetadataValueAnnotationTests.cs
+++ b/tests/Light.PortableResults.Tests/MetadataValueAnnotationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions;
+using Light.PortableResults.CloudEvents.Writing;
 using Light.PortableResults.Metadata;
 using Xunit;
 
@@ -40,11 +41,51 @@ public sealed class MetadataValueAnnotationTests
     }
 
     [Fact]
-    public void FromDecimal_WithAnnotation_SetsAnnotation()
+    public void FromDecimal_WithoutAnnotation_UsesDefaultAnnotation()
     {
         var value = MetadataValue.FromDecimal(123.45m);
 
         value.Annotation.Should().Be(MetadataValueAnnotation.SerializeInBodies);
+    }
+
+    [Fact]
+    public void FromDecimal_WithAnnotation_SetsAnnotation()
+    {
+        var value = MetadataValue.FromDecimal(123.45m, MetadataValueAnnotation.SerializeInHttpHeader);
+
+        value.Annotation.Should().Be(MetadataValueAnnotation.SerializeInHttpHeader);
+    }
+
+    // Decimals are primitive, thus they must be accepted in the two places where the primitive classification
+    // is enforced: header-annotated arrays and CloudEvents extension attributes.
+    [Fact]
+    public void FromArray_WithDecimals_AllowsHeaderAnnotation()
+    {
+        var array = MetadataArray.Create(
+            MetadataValue.FromDecimal(9.99m),
+            MetadataValue.FromDecimal(19.99m)
+        );
+
+        array.HasOnlyPrimitiveChildren.Should().BeTrue();
+        var value = MetadataValue.FromArray(array, MetadataValueAnnotation.SerializeInHttpHeader);
+
+        value.Annotation.Should().Be(MetadataValueAnnotation.SerializeInHttpHeader);
+    }
+
+    [Fact]
+    public void FromDecimal_AllowsCloudEventsExtensionAttributeAnnotation()
+    {
+        var value = MetadataValue.FromDecimal(
+            19.99m,
+            MetadataValueAnnotation.SerializeInCloudEventsExtensionAttributes
+        );
+
+        var attribute = DefaultCloudEventsAttributeConversionService.Instance.PrepareCloudEventsAttribute(
+            "price",
+            value
+        );
+
+        attribute.Value.Kind.Should().Be(MetadataKind.Decimal);
     }
 
     [Fact]

--- a/tests/Light.PortableResults.Tests/SharedJsonSerialization/Writing/SharedWritingExtensionsTests.cs
+++ b/tests/Light.PortableResults.Tests/SharedJsonSerialization/Writing/SharedWritingExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -116,6 +117,49 @@ public sealed class SharedWritingExtensionsTests
         );
 
         json.Should().Be("{\"metadata\":{\"traceId\":\"abc\"}}");
+    }
+
+    [Theory]
+    [InlineData("19.99", "19.99")]
+    [InlineData("19.50", "19.50")]
+    [InlineData("-0.0001", "-0.0001")]
+    [InlineData("79228162514264337593543950335", "79228162514264337593543950335")]
+    public void WriteMetadataValue_ShouldWriteDecimalAsUnquotedNumber(string input, string expectedJson)
+    {
+        var value = MetadataValue.FromDecimal(decimal.Parse(input, CultureInfo.InvariantCulture));
+
+        var json = Serialize(
+            writer => writer.WriteMetadataValue(value, MetadataValueAnnotation.SerializeInHttpResponseBody)
+        );
+
+        json.Should().Be(expectedJson);
+    }
+
+    [Fact]
+    public void WriteMetadataObject_ShouldWriteDecimalPropertyAsUnquotedNumber()
+    {
+        var metadata = MetadataObject.Create(("comparativeValue", MetadataValue.FromDecimal(19.99m)));
+
+        var json = Serialize(
+            writer => writer.WriteMetadataObject(metadata, MetadataValueAnnotation.SerializeInHttpResponseBody)
+        );
+
+        json.Should().Be("{\"comparativeValue\":19.99}");
+    }
+
+    [Fact]
+    public void WriteMetadataArray_ShouldWriteDecimalElementsAsUnquotedNumbers()
+    {
+        var array = MetadataArray.Create(
+            MetadataValue.FromDecimal(9.99m),
+            MetadataValue.FromDecimal(99.90m)
+        );
+
+        var json = Serialize(
+            writer => writer.WriteMetadataArray(array, MetadataValueAnnotation.SerializeInHttpResponseBody)
+        );
+
+        json.Should().Be("[9.99,99.90]");
     }
 
     [Fact]

--- a/tests/Light.PortableResults.Validation.OpenApi.Tests/DecimalMetadataOpenApiConformanceTests.cs
+++ b/tests/Light.PortableResults.Validation.OpenApi.Tests/DecimalMetadataOpenApiConformanceTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Light.PortableResults.AspNetCore.MinimalApis;
+using Light.PortableResults.AspNetCore.OpenApi;
+using Light.PortableResults.Http.Writing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+using Xunit;
+
+namespace Light.PortableResults.Validation.OpenApi.Tests;
+
+// This is the defect that motivated MetadataKind.Decimal: comparison and range rules on decimal-typed values
+// used to serialize their metadata as quoted strings, while the OpenAPI document generated for the very same
+// endpoint documents them as numbers.
+public sealed class DecimalMetadataOpenApiConformanceTests
+{
+    [Fact]
+    public async Task DecimalValidationProblemBody_ShouldConformToGeneratedOpenApiDocument()
+    {
+        await using var app = CreateApp();
+        var document = await ValidationOpenApiDocumentTestUtilities.GetOpenApiDocumentAsync(app);
+        using var httpClient = app.GetTestClient();
+
+        using var response = await httpClient.PostAsync(
+            "/decimal-validation",
+            content: null,
+            TestContext.Current.CancellationToken
+        );
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        body.Should().Contain("\"comparativeValue\":19.99");
+        body.Should().Contain("\"lowerBoundary\":9.99");
+        body.Should().Contain("\"upperBoundary\":99.99");
+
+        using var jsonDocument = JsonDocument.Parse(body);
+        var errors = jsonDocument.RootElement.GetProperty("errors").EnumerateArray().ToArray();
+
+        var greaterThanMetadata = GetMetadata(errors, ValidationErrorCodes.GreaterThan);
+        var inRangeMetadata = GetMetadata(errors, ValidationErrorCodes.InRange);
+
+        greaterThanMetadata.GetProperty("comparativeValue").ValueKind.Should().Be(JsonValueKind.Number);
+        greaterThanMetadata.GetProperty("comparativeValue").GetDecimal().Should().Be(19.99m);
+        inRangeMetadata.GetProperty("lowerBoundary").ValueKind.Should().Be(JsonValueKind.Number);
+        inRangeMetadata.GetProperty("upperBoundary").ValueKind.Should().Be(JsonValueKind.Number);
+
+        GetMetadataPropertySchema(document, ValidationErrorCodes.GreaterThan, "comparativeValue")
+           .Should()
+           .Match<OpenApiSchema>(
+                schema => ValidationOpenApiDocumentTestUtilities.SchemaIncludesType(schema, JsonSchemaType.Number)
+            );
+        GetMetadataPropertySchema(document, ValidationErrorCodes.InRange, "lowerBoundary")
+           .Should()
+           .Match<OpenApiSchema>(
+                schema => ValidationOpenApiDocumentTestUtilities.SchemaIncludesType(schema, JsonSchemaType.Number)
+            );
+        GetMetadataPropertySchema(document, ValidationErrorCodes.InRange, "upperBoundary")
+           .Should()
+           .Match<OpenApiSchema>(
+                schema => ValidationOpenApiDocumentTestUtilities.SchemaIncludesType(schema, JsonSchemaType.Number)
+            );
+    }
+
+    private static WebApplication CreateApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddPortableResultsForMinimalApis();
+        builder.Services.AddValidationForPortableResults();
+        builder.Services.AddSingleton<DecimalPriceValidator>();
+        builder.Services.AddPortableResultsOpenApi(contracts => contracts.RegisterBuiltInValidationErrors());
+        builder.Services.Configure<PortableResultsHttpWriteOptions>(
+            options => options.ValidationProblemSerializationFormat = ValidationProblemSerializationFormat.Rich
+        );
+        builder.Services.AddOpenApi();
+
+        var app = builder.Build();
+        app.MapPost("/decimal-validation", ValidateFixedPrice)
+           .WithName("DecimalValidation")
+           .ProducesPortableValidationProblemFor<DecimalPriceValidator>(
+                configure: static openApi => openApi.UseFormat(ValidationProblemSerializationFormat.Rich)
+            );
+        return app;
+    }
+
+    private static IResult ValidateFixedPrice(DecimalPriceValidator validator)
+    {
+        var dto = new DecimalPriceDto { Price = 5.00m, Discount = 199.00m };
+        var validationContext = validator.ValidationContextFactory.CreateValidationContext();
+        return validator.CheckForErrors(dto, validationContext, out var errorResult) ?
+            Result<DecimalPriceDto>.Fail(errorResult.Errors).ToMinimalApiResult() :
+            Result<DecimalPriceDto>.Ok(dto).ToMinimalApiResult();
+    }
+
+    private static JsonElement GetMetadata(JsonElement[] errors, string errorCode)
+    {
+        var error = errors.Single(element => element.GetProperty("code").GetString() == errorCode);
+        return error.GetProperty("metadata");
+    }
+
+    private static OpenApiSchema GetMetadataPropertySchema(
+        OpenApiDocument document,
+        string errorCode,
+        string metadataKey
+    )
+    {
+        var response = (OpenApiResponse) document.Paths["/decimal-validation"]
+           .Operations![HttpMethod.Post]
+           .Responses![StatusCodes.Status400BadRequest.ToString()];
+        var envelopeReference = (OpenApiSchemaReference) response.Content!["application/problem+json"].Schema!;
+        var envelope = ValidationOpenApiDocumentTestUtilities.GetSchemaComponent(
+            document,
+            ValidationOpenApiDocumentTestUtilities.GetSchemaReferenceId(envelopeReference)
+        );
+        var errorItems = (OpenApiSchema) ((OpenApiSchema) envelope.Properties!["errors"]).Items!;
+        var errorSchemaId = errorItems.OneOf!
+           .Select(
+                static schema =>
+                    ValidationOpenApiDocumentTestUtilities.GetSchemaReferenceId((OpenApiSchemaReference) schema)
+            )
+           .Single(schemaId => schemaId.EndsWith("__" + errorCode, StringComparison.Ordinal));
+        var metadataSchema = ValidationOpenApiDocumentTestUtilities.GetSchemaComponent(
+            document,
+            errorSchemaId + "__Metadata"
+        );
+        return (OpenApiSchema) metadataSchema.Properties![metadataKey];
+    }
+}
+
+public sealed class DecimalPriceDto
+{
+    public decimal Price { get; init; }
+    public decimal Discount { get; init; }
+}
+
+[GeneratePortableValidationOpenApi]
+public sealed partial class DecimalPriceValidator : Validator<DecimalPriceDto>
+{
+    public DecimalPriceValidator(IValidationContextFactory validationContextFactory)
+        : base(validationContextFactory) { }
+
+    protected override ValidatedValue<DecimalPriceDto> PerformValidation(
+        ValidationContext context,
+        ValidationCheckpoint checkpoint,
+        DecimalPriceDto dto
+    )
+    {
+        context.Check(dto.Price).IsGreaterThan(19.99m);
+        context.Check(dto.Discount).IsInRange(9.99m, 99.99m);
+        return checkpoint.ToValidatedValue(dto);
+    }
+}


### PR DESCRIPTION
Closes #52.

Implemented as stated in the corresponding issue, following `ai-plans/0052-decimal-metadata-kind.md`.

`MetadataValue.FromDecimal` used to convert its input to invariant text and store `MetadataKind.String`, so decimals serialized into JSON bodies as quoted strings while the OpenAPI document generated for the same endpoint described them as numbers. Any `IsGreaterThan(19.99m)` or `IsInRange(9.99m, 99.99m)` check therefore produced a `problem+json` body that violated its own published contract. This introduces a dedicated `MetadataKind.Decimal` backed by a boxed `decimal`.

## What changed

- **`MetadataKind.Decimal = 5`**, appended to the primitive block. `IsPrimitive` is `kind < MetadataKind.Array`, so membership is decided purely by ordering — declaring `Decimal` after `Object` would have compiled cleanly and silently classified decimals as complex. `Array` and `Object` move to `200`/`201`, reserving `6-199` for future primitive kinds (CloudEvents' `Binary`, `URI`, `URI-reference`, and `Timestamp` are all flattened into `String` today).
- **Boxed storage in the existing `Reference` slot.** An inline 128-bit field would push `Reference` to offset 16 and grow every `MetadataValue` by 8 bytes, including elements stored inline in arrays and objects. `Unsafe.SizeOf<MetadataValue>()` is pinned at its pre-existing 24 bytes so a future layout change has to be deliberate.
- **Every `MetadataKind` dispatch site updated.** All six have a `default` arm or a silent fall-through, so adding the member broke nothing at compile time: `WriteMetadataValue` would have written JSON `null`, `Equals` would have made decimals unequal to themselves, `GetHashCode` would have hashed the kind alone, and a decimal-valued CloudEvents `subject` would have become `null`. Each is now handled and covered by a test.
- **Equality delegates to `decimal`**, which is scale-insensitive and consistent with `decimal.GetHashCode`.
- **Reader behaviour is specified rather than implied.** A JSON number carries no discriminator between a decimal and a double, so the reader keeps its `Int64`-then-`Double` behaviour and never produces `MetadataKind.Decimal`. This is documented on both `MetadataJsonReader` types and pinned by tests. Preferring `Decimal` would make the resulting kind depend on the magnitude of the value and would break round-tripping in the opposite direction.

## Breaking changes

Pre-1.0, and all of these are silent at compile time for downstream callers. They are listed in `PackageReleaseNotes`:

- `TryGetString` no longer returns `true` for decimals; `Kind` is no longer `MetadataKind.String`.
- Decimal metadata appears as a JSON number rather than a JSON string in serialized bodies.
- Decimals differing only in trailing zeros (`19.50m`, `19.5m`) now compare equal. Scale is still preserved for serialization.
- The numeric values of `MetadataKind.Array` and `MetadataKind.Object` change to `200` and `201`. Nothing in the solution casts `MetadataKind` to a numeric type and it is not exposed by the OpenAPI, Validation, or source-generation packages, but any consumer that persisted or transmitted the numeric value is affected.

## Verification

- Release build clean, 0 warnings with `TreatWarningsAsErrors`.
- 2235 tests pass.
- Merged line coverage 95.4% (branch 89.3%), measured through the same `reportgenerator` path CI uses.
- The criterion that carries the actual defect is an integration test that triggers comparison and range failures on decimal-typed values, then asserts the raw `problem+json` body carries unquoted numbers *and* that the generated OpenAPI document types the same properties as `number`.

The last commit applies review findings: the decimal arms of `Equals` and `ToString` now match the payload with a pattern instead of an unchecked cast, two `MetadataKind` tests that could not fail were replaced by a pin on every member's numeric value, and the size pin asserts process bitness before its 64-bit literal.

## Follow-up

#53 — writing extension attributes as JSON numbers is outside the CloudEvents type system, which is closed and has no fractional type. This predates the PR (`Double` and out-of-int32-range `Int64` behave the same way); it is not a regression from this change, but `Decimal` did move from the accidentally conformant column into the same bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNvxUqG5x5wF3d1vfzx3kj
